### PR TITLE
Feature: Handle remigration of swagger artifacts in Maven Central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite:rewrite-gradle")
     testImplementation("org.openrewrite:rewrite-maven")
+    testImplementation("org.openrewrite:rewrite-core")
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:latest.release")
 

--- a/src/main/resources/META-INF/rewrite/swagger-2.yml
+++ b/src/main/resources/META-INF/rewrite/swagger-2.yml
@@ -27,19 +27,16 @@ recipeList:
       oldGroupId: io.swagger
       oldArtifactId: swagger-annotations
       newGroupId: io.swagger.core.v3
-      newArtifactId: swagger-annotations
       newVersion: 2.2.x
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: io.swagger
       oldArtifactId: swagger-core
       newGroupId: io.swagger.core.v3
-      newArtifactId: swagger-core
       newVersion: 2.2.x
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: io.swagger
       oldArtifactId: swagger-models
       newGroupId: io.swagger.core.v3
-      newArtifactId: swagger-models
       newVersion: 2.2.x
   # https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Annotations
   # https://springdoc.org/#migrating-from-springfox

--- a/src/main/resources/META-INF/rewrite/swagger-2.yml
+++ b/src/main/resources/META-INF/rewrite/swagger-2.yml
@@ -22,6 +22,25 @@ tags:
   - swagger
   - openapi
 recipeList:
+  # Relocated artifacts https://mvnrepository.com/artifact/io.swagger
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: io.swagger
+      oldArtifactId: swagger-annotations
+      newGroupId: io.swagger.core.v3
+      newArtifactId: swagger-annotations
+      newVersion: 2.2.x
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: io.swagger
+      oldArtifactId: swagger-core
+      newGroupId: io.swagger.core.v3
+      newArtifactId: swagger-core
+      newVersion: 2.2.x
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: io.swagger
+      oldArtifactId: swagger-models
+      newGroupId: io.swagger.core.v3
+      newArtifactId: swagger-models
+      newVersion: 2.2.x
   # https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Annotations
   # https://springdoc.org/#migrating-from-springfox
   - org.openrewrite.java.ChangeType:

--- a/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
@@ -20,6 +20,9 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.maven.Assertions.pomXml;
+
 class SwaggerToOpenAPITest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
@@ -32,5 +35,81 @@ class SwaggerToOpenAPITest implements RewriteTest {
         rewriteRun(
           spec-> spec.printRecipe(() -> System.out::println)
         );
+    }
+
+    @Test
+    void shouldChangeSwaggerArtifacts() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+            package example.org;
+            
+            import io.swagger.annotations.ApiModel;
+
+            @ApiModel
+            class Example { }
+            """,
+            """
+            package example.org;
+            
+            import io.swagger.v3.oas.annotations.media.Schema;
+
+            @Schema
+            class Example { }
+            """
+          ),
+          //language=xml
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example</groupId>
+                <artifactId>demo</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>io.swagger</groupId>
+                    <artifactId>swagger-annotations</artifactId>
+                    <version>1.6.14</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>io.swagger</groupId>
+                    <artifactId>swagger-models</artifactId>
+                    <version>1.6.14</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>io.swagger</groupId>
+                    <artifactId>swagger-core</artifactId>
+                    <version>1.6.14</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example</groupId>
+                <artifactId>demo</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>io.swagger.core.v3</groupId>
+                    <artifactId>swagger-annotations</artifactId>
+                    <version>2.2.21</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>io.swagger.core.v3</groupId>
+                    <artifactId>swagger-models</artifactId>
+                    <version>2.2.21</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>io.swagger.core.v3</groupId>
+                    <artifactId>swagger-core</artifactId>
+                    <version>2.2.21</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """));
     }
 }

--- a/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
@@ -16,11 +16,12 @@
 package org.openrewrite.openapi.swagger;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class SwaggerToOpenAPITest implements RewriteTest {

--- a/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
@@ -37,6 +37,7 @@ class SwaggerToOpenAPITest implements RewriteTest {
         );
     }
 
+    @DocumentExample
     @Test
     void shouldChangeSwaggerArtifacts() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
* 3 artifacts that previously lived under the groupId `io.swagger` were relocated to `io.swagger.core.v3`, specifically:
  * `swagger-core`
  * `swagger-annotations`
  * `swagger-models`


## What's your motivation?
* The existing recipe does not handle the different groupIds yet and leads to code that does not compile
* It _might_ partially resolve https://github.com/openrewrite/rewrite-openapi/issues/3

## Anything in particular you'd like reviewers to focus on?
* Is the test-case good enough?

## Anyone you would like to review specifically?
-

## Have you considered any alternatives or workarounds?
* None come to mind

## Any additional context
* Looking at https://mvnrepository.com/artifact/io.swagger these seem to be the only relocated artifacts

### Checklist
- [x] I've added unit tests to cover both positive and negative cases...kinda - no negative tests cases here 😢 
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
