### PR TITLE
Update swagger-2.yml - Change attribute description to title

### DIFF
--- a/src/main/resources/META-INF/rewrite/swagger-2.yml
+++ b/src/main/resources/META-INF/rewrite/swagger-2.yml
@@ -224,10 +224,6 @@ recipeList:
       newFullyQualifiedTypeName: io.swagger.v3.oas.annotations.Parameter
   - org.openrewrite.java.ChangeAnnotationAttributeName:
       annotationType: io.swagger.v3.oas.annotations.Parameter
-      oldAttributeName: "description"
-      newAttributeName: "title"
-  - org.openrewrite.java.ChangeAnnotationAttributeName:
-      annotationType: io.swagger.v3.oas.annotations.Parameter
       oldAttributeName: "value"
       newAttributeName: "description"
 
@@ -243,6 +239,10 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: io.swagger.annotations.ApiModelProperty
       newFullyQualifiedTypeName: io.swagger.v3.oas.annotations.media.Schema
+  - org.openrewrite.java.ChangeAnnotationAttributeName:
+      annotationType: io.swagger.v3.oas.annotations.Parameter
+      oldAttributeName: "description"
+      newAttributeName: "title"
   - org.openrewrite.java.ChangeAnnotationAttributeName:
       annotationType: io.swagger.v3.oas.annotations.media.Schema
       oldAttributeName: "value"

--- a/src/main/resources/META-INF/rewrite/swagger-2.yml
+++ b/src/main/resources/META-INF/rewrite/swagger-2.yml
@@ -224,6 +224,10 @@ recipeList:
       newFullyQualifiedTypeName: io.swagger.v3.oas.annotations.Parameter
   - org.openrewrite.java.ChangeAnnotationAttributeName:
       annotationType: io.swagger.v3.oas.annotations.Parameter
+      oldAttributeName: "description"
+      newAttributeName: "title"
+  - org.openrewrite.java.ChangeAnnotationAttributeName:
+      annotationType: io.swagger.v3.oas.annotations.Parameter
       oldAttributeName: "value"
       newAttributeName: "description"
 


### PR DESCRIPTION
Change attribute "description" to "title"

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Change attribute "description" to "title" when migrating from ApiModel to io.swagger.v3.oas.annotations.media.Schema

## What's your motivation?
I ran this recipe and it changed "value" to "description" but didn't change what was currently "description" to anything. After some digging, I found that its counterpart would be "title"

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
