### PR TITLE
Add MigrateSpringdocCommon recipe

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:latest.release")
 
     testRuntimeOnly("io.swagger:swagger-annotations:1.6.13")
+    testRuntimeOnly("org.springdoc:springdoc-openapi-common:1.6.8")
     testRuntimeOnly("io.swagger.core.v3:swagger-annotations:2.2.20")
 
     testRuntimeOnly("org.gradle:gradle-tooling-api:latest.release")

--- a/src/main/resources/META-INF/rewrite/springdoc-common.yml
+++ b/src/main/resources/META-INF/rewrite/springdoc-common.yml
@@ -1,0 +1,33 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.openapi.springdoc.MigrateSpringdocCommon
+displayName: Migrate from springdoc-openapi-common to springdoc-openapi-starter-common
+description: Migrate from springdoc-openapi-common to springdoc-openapi-starter-common.
+tags:
+  - springdoc
+  - openapi
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springdoc.core.customizers.OpenApiCustomiser
+      newFullyQualifiedTypeName: org.springdoc.core.customizers.OpenApiCustomizer
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.springdoc.core.GroupedOpenApi.Builder addOpenApiCustomiser(..)
+      newMethodName: addOpenApiCustomizer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springdoc.core.GroupedOpenApi
+      newFullyQualifiedTypeName: org.springdoc.core.models.GroupedOpenApi

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateSpringdocCommonTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateSpringdocCommonTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.openapi.swagger;
+
+import org.junit.jupiter.api.Test;
+import static org.openrewrite.java.Assertions.java;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+public class MigrateSpringdocCommonTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.openapi.springdoc.MigrateSpringdocCommon")
+          .parser(JavaParser.fromJavaVersion().classpath(
+            "springdoc-openapi-common-1.+",
+            "swagger-models-2.+"
+        ));
+    }
+    @Test
+    public void fixCustomiserAndGroupedOpenApi() {
+        // language=java
+        rewriteRun(
+          spec -> spec.afterTypeValidationOptions(TypeValidation.none()),
+          java(
+            """
+              import io.swagger.v3.oas.models.OpenAPI;
+              import org.springdoc.core.GroupedOpenApi;
+              import org.springdoc.core.customizers.OpenApiCustomiser;
+
+              public class OpenApiConfiguration {
+
+                  public static void groupedOpenApi() {
+                      GroupedOpenApi.builder()
+                        .group("group")
+                        .pathsToMatch("/api/**")
+                        .addOpenApiCustomiser(new FoobarOpenApiCustomiser())
+                        .build();
+                  }
+
+                  public static class FoobarOpenApiCustomiser implements OpenApiCustomiser {
+                      @Override
+                      public void customise(OpenAPI openApi) {
+                      }
+                  }
+              }
+              """, """
+              import io.swagger.v3.oas.models.OpenAPI;
+              import org.springdoc.core.customizers.OpenApiCustomizer;
+              import org.springdoc.core.models.GroupedOpenApi;
+
+              public class OpenApiConfiguration {
+
+                  public static void groupedOpenApi() {
+                      GroupedOpenApi.builder()
+                        .group("group")
+                        .pathsToMatch("/api/**")
+                        .addOpenApiCustomizer(new FoobarOpenApiCustomiser())
+                        .build();
+                  }
+
+                  public static class FoobarOpenApiCustomiser implements OpenApiCustomizer {
+                      @Override
+                      public void customise(OpenAPI openApi) {
+                      }
+                  }
+              }
+              """
+          ));
+    }
+}

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateSpringdocCommonTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateSpringdocCommonTest.java
@@ -29,8 +29,9 @@ public class MigrateSpringdocCommonTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion().classpath(
             "springdoc-openapi-common-1.+",
             "swagger-models-2.+"
-        ));
+          ));
     }
+
     @Test
     public void fixCustomiserAndGroupedOpenApi() {
         // language=java

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateSpringdocCommonTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateSpringdocCommonTest.java
@@ -16,8 +16,10 @@
 package org.openrewrite.openapi.swagger;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import static org.openrewrite.java.Assertions.java;
-import org.openrewrite.java.JavaParser;
+
+class MigrateSpringdocCommonTest implements RewriteTest {
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
@@ -32,7 +34,8 @@ public class MigrateSpringdocCommonTest implements RewriteTest {
           ));
     }
 
-    @Test
+    @DocumentExample
+    void fixCustomiserAndGroupedOpenApi() {
     public void fixCustomiserAndGroupedOpenApi() {
         // language=java
         rewriteRun(


### PR DESCRIPTION
## What's changed?
There're a little changes between springdoc-openapi-common-1.+ and springdoc-openapi-starter-common-2.+
1. `org.springdoc.core.customizers.OpenApiCustomiser` => `org.springdoc.core.customizers.OpenApiCustomizer`
2. `org.springdoc.core.GroupedOpenApi` => `org.springdoc.core.models.GroupedOpenApi`
3. `addOpenApiCustomiser()` => `addOpenApiCustomizer()`

### Checklist
- [✅] I've added unit tests to cover both positive and negative cases
- [✅] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [✅] I've used the IntelliJ IDEA auto-formatter on affected files
