### PR TITLE
Handle multiple tags in @Api

### DIFF
--- a/src/main/java/org/openrewrite/openapi/swagger/MigrateApiToTag.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/MigrateApiToTag.java
@@ -34,10 +34,11 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptyList;
 import static org.openrewrite.Tree.randomId;
 
+public class MigrateApiToTag extends Recipe {
+
     private static final String FQN_API = "io.swagger.annotations.Api";
     private static final String FQN_TAG = "io.swagger.v3.oas.annotations.tags.Tag";
     private static final String FQN_TAGS = "io.swagger.v3.oas.annotations.tags.Tags";
-    private static final JavaType TYPE_TAG = JavaType.buildType(FQN_TAG);
 
     @Override
     public String getDisplayName() {
@@ -52,104 +53,104 @@ import static org.openrewrite.Tree.randomId;
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
-          new UsesType<>(FQN_API, false),
-          new JavaIsoVisitor<ExecutionContext>() {
-              private final AnnotationMatcher apiMatcher = new AnnotationMatcher(FQN_API);
+                new UsesType<>(FQN_API, false),
+                new JavaIsoVisitor<ExecutionContext>() {
+                    private final AnnotationMatcher apiMatcher = new AnnotationMatcher(FQN_API);
 
-              @Override
-              public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
-                  annotation = super.visitAnnotation(annotation, ctx);
-                  if (apiMatcher.matches(annotation)) {
-                      List<Expression> arguments = annotation.getArguments();
-                      boolean hasTags = arguments
-                        .stream()
-                        .filter(J.Assignment.class::isInstance)
-                        .map(J.Assignment.class::cast).
-                        anyMatch(o -> "tags".equals(o.getVariable().printTrimmed()));
-                      if (hasTags) {
-                          getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, FQN_API, annotation);
-                          // Only remove @Api
-                          annotation = null;
-                      } else {
-                          doAfterVisit(new ChangeAnnotationAttributeName(FQN_API, "value", "name").getVisitor());
-                      }
+                    @Override
+                    public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                        annotation = super.visitAnnotation(annotation, ctx);
+                        if (apiMatcher.matches(annotation)) {
+                            List<Expression> arguments = annotation.getArguments();
+                            boolean hasTags = arguments
+                                    .stream()
+                                    .filter(J.Assignment.class::isInstance)
+                                    .map(J.Assignment.class::cast).
+                                    anyMatch(o -> "tags".equals(o.getVariable().printTrimmed()));
+                            if (hasTags) {
+                                getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, FQN_API, annotation);
+                                // Only remove @Api
+                                annotation = null;
+                            } else {
+                                doAfterVisit(new ChangeAnnotationAttributeName(FQN_API, "value", "name").getVisitor());
+                            }
 
-                      doAfterVisit(new ChangeType(FQN_API, FQN_TAG, true).getVisitor());
-                  }
-                  return annotation;
-              }
+                            doAfterVisit(new ChangeType(FQN_API, FQN_TAG, true).getVisitor());
+                        }
+                        return annotation;
+                    }
 
-              @Override
-              public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
-                  classDecl = super.visitClassDeclaration(classDecl, ctx);
+                    @Override
+                    public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                        classDecl = super.visitClassDeclaration(classDecl, ctx);
 
-                  J.Annotation apiAnnotation = getCursor().getMessage(FQN_API);
-                  if (apiAnnotation != null) {
-                      List<J.Assignment> arguments = apiAnnotation.getArguments().stream()
-                        .filter(J.Assignment.class::isInstance)
-                        .map(J.Assignment.class::cast)
-                        .collect(Collectors.toList());
+                        J.Annotation apiAnnotation = getCursor().getMessage(FQN_API);
+                        if (apiAnnotation != null) {
+                            List<J.Assignment> arguments = apiAnnotation.getArguments().stream()
+                                    .filter(J.Assignment.class::isInstance)
+                                    .map(J.Assignment.class::cast)
+                                    .collect(Collectors.toList());
 
-                      // Get the description from the @Api annotation
-                      String desc = arguments.stream()
-                        .filter(o -> "description".equals(o.getVariable().printTrimmed()))
-                        .findFirst()
-                        .map(assignment -> assignment.getAssignment().printTrimmed())
-                        .orElse(null);
+                            // Get the description from the @Api annotation
+                            String desc = arguments.stream()
+                                    .filter(o -> "description".equals(o.getVariable().printTrimmed()))
+                                    .findFirst()
+                                    .map(assignment -> assignment.getAssignment().printTrimmed())
+                                    .orElse(null);
 
-                      // Get the tags from the @Api annotation
-                      String tags = arguments.stream()
-                        .filter(o -> "tags".equals(o.getVariable().printTrimmed()))
-                        .findFirst()
-                        .map(o -> ((J.NewArray) o.getAssignment()).getInitializer().stream()
-                          .map(J::printTrimmed)
-                          .map(t -> "@Tag(name=" + t + (desc != null ? ", description=" + desc : "") + ")")
-                          .collect(Collectors.joining(",\n"))
-                        )
-                        .orElse(null);
-                      if (tags != null) {
-                          List<J.Annotation> origin = classDecl.getLeadingAnnotations();
-                          origin.add(buildTags(tags));
-                          classDecl = classDecl.withLeadingAnnotations(origin);
+                            // Get the tags from the @Api annotation
+                            String tags = arguments.stream()
+                                    .filter(o -> "tags".equals(o.getVariable().printTrimmed()))
+                                    .findFirst()
+                                    .map(o -> ((J.NewArray) o.getAssignment()).getInitializer().stream()
+                                            .map(J::printTrimmed)
+                                            .map(t -> "@Tag(name=" + t + (desc != null ? ", description=" + desc : "") + ")")
+                                            .collect(Collectors.joining(",\n"))
+                                    )
+                                    .orElse(null);
+                            if (tags != null) {
+                                List<J.Annotation> origin = classDecl.getLeadingAnnotations();
+                                origin.add(buildTags(tags));
+                                classDecl = classDecl.withLeadingAnnotations(origin);
 
-                          // Force import @Tag
-                          maybeAddImport(FQN_TAG, false);
-                          maybeAddImport(FQN_TAGS);
-                      }
-                  }
+                                // Force import @Tag
+                                maybeAddImport(FQN_TAG, false);
+                                maybeAddImport(FQN_TAGS);
+                            }
+                        }
 
-                  return classDecl;
-              }
+                        return classDecl;
+                    }
 
-              private J.Annotation buildTags(String tags) {
-                  J.Identifier id = new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), "Tags", JavaType.buildType(FQN_TAGS), null);
-                  return new J.Annotation(
-                    randomId(),
-                    Space.EMPTY,
-                    Markers.EMPTY,
-                    id,
-                    JContainer.build(
-                      Space.EMPTY,
-                      Collections.singletonList(
-                        new JRightPadded<>(
-                          new J.Literal(
-                            randomId(),
-                            Space.EMPTY,
-                            Markers.EMPTY,
-                            FQN_TAGS,
-                            "{\n" + tags + "\n}",
-                            null,
-                            JavaType.Primitive.String
-                          ),
-                          Space.EMPTY,
-                          Markers.EMPTY
-                        )
-                      ),
-                      Markers.EMPTY
-                    )
-                  );
-              }
-          }
+                    private J.Annotation buildTags(String tags) {
+                        J.Identifier id = new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), "Tags", JavaType.buildType(FQN_TAGS), null);
+                        return new J.Annotation(
+                                randomId(),
+                                Space.EMPTY,
+                                Markers.EMPTY,
+                                id,
+                                JContainer.build(
+                                        Space.EMPTY,
+                                        Collections.singletonList(
+                                                new JRightPadded<>(
+                                                        new J.Literal(
+                                                                randomId(),
+                                                                Space.EMPTY,
+                                                                Markers.EMPTY,
+                                                                FQN_TAGS,
+                                                                "{\n" + tags + "\n}",
+                                                                null,
+                                                                JavaType.Primitive.String
+                                                        ),
+                                                        Space.EMPTY,
+                                                        Markers.EMPTY
+                                                )
+                                        ),
+                                        Markers.EMPTY
+                                )
+                        );
+                    }
+                }
         );
     }
 }

--- a/src/main/java/org/openrewrite/openapi/swagger/MigrateApiToTag.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/MigrateApiToTag.java
@@ -15,10 +15,14 @@
  */
 package org.openrewrite.openapi.swagger;
 
-import static java.util.Collections.emptyList;
-import org.openrewrite.*;
-import static org.openrewrite.Tree.randomId;
-import org.openrewrite.java.*;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.ChangeAnnotationAttributeName;
+import org.openrewrite.java.ChangeType;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
@@ -27,7 +31,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class MigrateApiToTag extends Recipe {
+import static java.util.Collections.emptyList;
+import static org.openrewrite.Tree.randomId;
+
     private static final String FQN_API = "io.swagger.annotations.Api";
     private static final String FQN_TAG = "io.swagger.v3.oas.annotations.tags.Tag";
     private static final String FQN_TAGS = "io.swagger.v3.oas.annotations.tags.Tags";

--- a/src/main/java/org/openrewrite/openapi/swagger/MigrateApiToTag.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/MigrateApiToTag.java
@@ -52,6 +52,7 @@ public class MigrateApiToTag extends Recipe {
                                              "public @interface Tags {\n" +
                                              "    Tag[] value() default {};\n" +
                                              "}";
+
     @Language("java")
     private static final String TAG_CLASS = "package io.swagger.v3.oas.annotations.tags;\n" +
                                             "import java.lang.annotation.ElementType;\n" +
@@ -185,9 +186,8 @@ public class MigrateApiToTag extends Recipe {
 
                         // Add formatted template and imports
                         maybeAddImport(FQN_TAG);
-                        maybeAddImport(FQN_TAGS);
                         return JavaTemplate.builder(template.toString())
-                                .imports(FQN_TAGS, FQN_TAG)
+                                .imports(FQN_TAG)
                                 .javaParser(JavaParser.fromJavaVersion().dependsOn(TAGS_CLASS, TAG_CLASS))
                                 .build()
                                 .apply(updateCursor(cd), cd.getCoordinates().addAnnotation(comparing(J.Annotation::getSimpleName)), templateArgs.toArray());

--- a/src/main/java/org/openrewrite/openapi/swagger/MigrateApiToTag.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/MigrateApiToTag.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.openapi.swagger;
+
+import static java.util.Collections.emptyList;
+import org.openrewrite.*;
+import static org.openrewrite.Tree.randomId;
+import org.openrewrite.java.*;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MigrateApiToTag extends Recipe {
+    private static final String FQN_API = "io.swagger.annotations.Api";
+    private static final String FQN_TAG = "io.swagger.v3.oas.annotations.tags.Tag";
+    private static final String FQN_TAGS = "io.swagger.v3.oas.annotations.tags.Tags";
+    private static final JavaType TYPE_TAG = JavaType.buildType(FQN_TAG);
+
+    @Override
+    public String getDisplayName() {
+        return "Migrate from `@Api` to `@Tag`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Converts `@Api` to `@Tag` annotation and converts the directly mappable attributes and removes the others.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+          new UsesType<>(FQN_API, false),
+          new JavaIsoVisitor<ExecutionContext>() {
+              private final AnnotationMatcher apiMatcher = new AnnotationMatcher(FQN_API);
+
+              @Override
+              public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  annotation = super.visitAnnotation(annotation, ctx);
+                  if (apiMatcher.matches(annotation)) {
+                      List<Expression> arguments = annotation.getArguments();
+                      boolean hasTags = arguments
+                        .stream()
+                        .filter(J.Assignment.class::isInstance)
+                        .map(J.Assignment.class::cast).
+                        anyMatch(o -> "tags".equals(o.getVariable().printTrimmed()));
+                      if (hasTags) {
+                          getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, FQN_API, annotation);
+                          // Only remove @Api
+                          annotation = null;
+                      } else {
+                          doAfterVisit(new ChangeAnnotationAttributeName(FQN_API, "value", "name").getVisitor());
+                      }
+
+                      doAfterVisit(new ChangeType(FQN_API, FQN_TAG, true).getVisitor());
+                  }
+                  return annotation;
+              }
+
+              @Override
+              public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                  classDecl = super.visitClassDeclaration(classDecl, ctx);
+
+                  J.Annotation apiAnnotation = getCursor().getMessage(FQN_API);
+                  if (apiAnnotation != null) {
+                      List<J.Assignment> arguments = apiAnnotation.getArguments().stream()
+                        .filter(J.Assignment.class::isInstance)
+                        .map(J.Assignment.class::cast)
+                        .collect(Collectors.toList());
+
+                      // Get the description from the @Api annotation
+                      String desc = arguments.stream()
+                        .filter(o -> "description".equals(o.getVariable().printTrimmed()))
+                        .findFirst()
+                        .map(assignment -> assignment.getAssignment().printTrimmed())
+                        .orElse(null);
+
+                      // Get the tags from the @Api annotation
+                      String tags = arguments.stream()
+                        .filter(o -> "tags".equals(o.getVariable().printTrimmed()))
+                        .findFirst()
+                        .map(o -> ((J.NewArray) o.getAssignment()).getInitializer().stream()
+                          .map(J::printTrimmed)
+                          .map(t -> "@Tag(name=" + t + (desc != null ? ", description=" + desc : "") + ")")
+                          .collect(Collectors.joining(",\n"))
+                        )
+                        .orElse(null);
+                      if (tags != null) {
+                          List<J.Annotation> origin = classDecl.getLeadingAnnotations();
+                          origin.add(buildTags(tags));
+                          classDecl = classDecl.withLeadingAnnotations(origin);
+
+                          // Force import @Tag
+                          maybeAddImport(FQN_TAG, false);
+                          maybeAddImport(FQN_TAGS);
+                      }
+                  }
+
+                  return classDecl;
+              }
+
+              private J.Annotation buildTags(String tags) {
+                  J.Identifier id = new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), "Tags", JavaType.buildType(FQN_TAGS), null);
+                  return new J.Annotation(
+                    randomId(),
+                    Space.EMPTY,
+                    Markers.EMPTY,
+                    id,
+                    JContainer.build(
+                      Space.EMPTY,
+                      Collections.singletonList(
+                        new JRightPadded<>(
+                          new J.Literal(
+                            randomId(),
+                            Space.EMPTY,
+                            Markers.EMPTY,
+                            FQN_TAGS,
+                            "{\n" + tags + "\n}",
+                            null,
+                            JavaType.Primitive.String
+                          ),
+                          Space.EMPTY,
+                          Markers.EMPTY
+                        )
+                      ),
+                      Markers.EMPTY
+                    )
+                  );
+              }
+          }
+        );
+    }
+}

--- a/src/main/resources/META-INF/rewrite/swagger-2.yml
+++ b/src/main/resources/META-INF/rewrite/swagger-2.yml
@@ -193,23 +193,6 @@ recipeList:
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.openapi.swagger.MigrateApiToTag
-displayName: Migrate from `@Api` to `@Tag`
-description: Converts `@Api` to `@Tag` annotation and converts the directly mappable attributes and removes the others.
-tags:
-  - swagger
-  - openapi
-recipeList:
-  - org.openrewrite.java.ChangeAnnotationAttributeName:
-      annotationType: io.swagger.annotations.Api
-      oldAttributeName: "value"
-      newAttributeName: "name"
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: io.swagger.annotations.Api
-      newFullyQualifiedTypeName: io.swagger.v3.oas.annotations.tags.Tag
-
----
-type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.openapi.swagger.MigrateApiParamToParameter
 displayName: Migrate from `@ApiParam` to `@Parameter`
 description: Converts the `@ApiParam` annotation to `@Parameter` and converts the directly mappable attributes.

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateApiToTagTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateApiToTagTest.java
@@ -18,18 +18,17 @@ package org.openrewrite.openapi.swagger;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
 class MigrateApiToTagTest implements RewriteTest {
-import org.openrewrite.test.RecipeSpec;
-import org.openrewrite.test.RewriteTest;
 
-public class MigrateApiToTagTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResources("org.openrewrite.openapi.swagger.SwaggerToOpenAPI")
-          .parser(JavaParser.fromJavaVersion().classpath("swagger-annotations-1.+", "swagger-annotations-2.+"));
+          .parser(JavaParser.fromJavaVersion().classpath("swagger-annotations-1.+"));
     }
 
     @DocumentExample
@@ -54,7 +53,6 @@ public class MigrateApiToTagTest implements RewriteTest {
         );
     }
 
-    @DocumentExample
     @Test
     void multiple() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateApiToTagTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateApiToTagTest.java
@@ -54,14 +54,14 @@ class MigrateApiToTagTest implements RewriteTest {
     }
 
     @Test
-    void multiple() {
+    void multipleTags() {
         rewriteRun(
           //language=java
           java(
             """
               import io.swagger.annotations.Api;
 
-              @Api(tags={"foo", "bar"}, value = "Ignore", description = "Desc")
+              @Api(tags = {"foo", "bar"}, value = "Ignore", description = "Desc")
               class Example {}
               """,
             """
@@ -69,8 +69,8 @@ class MigrateApiToTagTest implements RewriteTest {
               import io.swagger.v3.oas.annotations.tags.Tags;
 
               @Tags({
-              @Tag(name="foo", description="Desc"),
-              @Tag(name="bar", description="Desc")
+                      @Tag(name = "foo", description = "Desc"),
+                      @Tag(name = "bar", description = "Desc")
               })
               class Example {}
               """

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateApiToTagTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateApiToTagTest.java
@@ -27,7 +27,7 @@ class MigrateApiToTagTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipeFromResources("org.openrewrite.openapi.swagger.SwaggerToOpenAPI")
+        spec.recipe(new MigrateApiToTag())
           .parser(JavaParser.fromJavaVersion().classpath("swagger-annotations-1.+"));
     }
 
@@ -47,6 +47,48 @@ class MigrateApiToTagTest implements RewriteTest {
               import io.swagger.v3.oas.annotations.tags.Tag;
 
               @Tag(name = "Bar")
+              class Example {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void singleTagAsArray() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import io.swagger.annotations.Api;
+
+              @Api(tags = {"foo"}, value = "Ignore", description = "Desc")
+              class Example {}
+              """,
+            """
+              import io.swagger.v3.oas.annotations.tags.Tag;
+
+              @Tag(name = "foo", description = "Desc")
+              class Example {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void singleTagAsLiteral() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import io.swagger.annotations.Api;
+
+              @Api(tags = "foo", value = "Ignore", description = "Desc")
+              class Example {}
+              """,
+            """
+              import io.swagger.v3.oas.annotations.tags.Tag;
+
+              @Tag(name = "foo", description = "Desc")
               class Example {}
               """
           )

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateApiToTagTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateApiToTagTest.java
@@ -17,8 +17,11 @@ package org.openrewrite.openapi.swagger;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import static org.openrewrite.java.Assertions.java;
 import org.openrewrite.java.JavaParser;
+
+import static org.openrewrite.java.Assertions.java;
+
+class MigrateApiToTagTest implements RewriteTest {
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateApiToTagTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateApiToTagTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.openapi.swagger;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import static org.openrewrite.java.Assertions.java;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+public class MigrateApiToTagTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.openapi.swagger.SwaggerToOpenAPI")
+          .parser(JavaParser.fromJavaVersion().classpath("swagger-annotations-1.+", "swagger-annotations-2.+"));
+    }
+
+    @DocumentExample
+    @Test
+    void single() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import io.swagger.annotations.Api;
+
+              @Api(value = "Bar")
+              class Example {}
+              """,
+            """
+              import io.swagger.v3.oas.annotations.tags.Tag;
+
+              @Tag(name = "Bar")
+              class Example {}
+              """
+          )
+        );
+    }
+
+    @DocumentExample
+    @Test
+    void multiple() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import io.swagger.annotations.Api;
+
+              @Api(tags={"foo", "bar"}, value = "Ignore", description = "Desc")
+              class Example {}
+              """,
+            """
+              import io.swagger.v3.oas.annotations.tags.Tag;
+              import io.swagger.v3.oas.annotations.tags.Tags;
+
+              @Tags({
+              @Tag(name="foo", description="Desc"),
+              @Tag(name="bar", description="Desc")
+              })
+              class Example {}
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
`MigrateApiToTag` doesn't handle the case where there're multiple `tags` in `@Api`

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
