### PR TITLE
Handle @ApiImplicitParam(dataTypeClass=..)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,8 @@ dependencies {
     implementation("org.openrewrite:rewrite-java")
     implementation("org.openrewrite.recipe:rewrite-java-dependencies:$rewriteVersion")
 
+    runtimeOnly("io.swagger.core.v3:swagger-annotations:2.2.20")
+
     testImplementation("org.openrewrite:rewrite-java-17")
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite:rewrite-gradle")
@@ -19,7 +21,6 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:latest.release")
 
     testRuntimeOnly("io.swagger:swagger-annotations:1.6.13")
-    testRuntimeOnly("io.swagger.core.v3:swagger-annotations:2.2.20")
 
     testRuntimeOnly("org.gradle:gradle-tooling-api:latest.release")
 }

--- a/src/main/java/org/openrewrite/openapi/swagger/MigrateApiImplicitParamDataTypeClass.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/MigrateApiImplicitParamDataTypeClass.java
@@ -15,8 +15,13 @@
  */
 package org.openrewrite.openapi.swagger;
 
-import org.openrewrite.*;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
@@ -38,43 +43,48 @@ public class MigrateApiImplicitParamDataTypeClass extends Recipe {
         return "Migrate `@ApiImplicitParam(dataTypeClass=Foo.class)` to `@Parameter(schema=@Schema(implementation=Foo.class))`.";
     }
 
-    private boolean isDataTypeClass(Expression exp) {
-        return exp instanceof J.Assignment && ((J.Identifier) ((J.Assignment) exp).getVariable()).getSimpleName().equals("dataTypeClass");
-    }
-
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         // This recipe is after ChangeType recipe
         return Preconditions.check(
-          new UsesMethod<>("io.swagger.annotations.ApiImplicitParam dataTypeClass()", false),
-          new JavaIsoVisitor<ExecutionContext>() {
-              @Override
-              public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
-                  J.Annotation anno = super.visitAnnotation(annotation, ctx);
+                new UsesMethod<>("io.swagger.annotations.ApiImplicitParam dataTypeClass()", false),
+                new JavaIsoVisitor<ExecutionContext>() {
+                    @Override
+                    public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                        J.Annotation anno = super.visitAnnotation(annotation, ctx);
 
-                  StringBuilder tpl = new StringBuilder();
-                  List<Expression> args = new ArrayList<>();
-                  for (Expression exp : annotation.getArguments()) {
-                      if (!args.isEmpty()) {
-                          tpl.append(", ");
-                      }
-                      if (isDataTypeClass(exp)) {
-                          J.FieldAccess fieldAccess = (J.FieldAccess) ((J.Assignment) exp).getAssignment();
-                          tpl.append("schema = @Schema(implementation = #{any()})");
-                          args.add(fieldAccess);
-                      } else {
-                          tpl.append("#{any()}");
-                          args.add(exp);
-                      }
-                  }
-                  anno = JavaTemplate.builder(tpl.toString())
-                    .imports(FQN_SCHEMA)
-                    .build()
-                    .apply(updateCursor(annotation), annotation.getCoordinates().replaceArguments(), args.toArray());
-                  maybeAddImport(FQN_SCHEMA, false);
-                  return maybeAutoFormat(annotation, anno, ctx, getCursor().getParentTreeCursor());
-              }
-          }
+                        if (!new AnnotationMatcher("io.swagger.v3.oas.annotations.Parameter").matches(anno)) {
+                            return anno;
+                        }
+
+                        StringBuilder tpl = new StringBuilder();
+                        List<Expression> args = new ArrayList<>();
+                        for (Expression exp : anno.getArguments()) {
+                            if (!args.isEmpty()) {
+                                tpl.append(", ");
+                            }
+                            if (isDataTypeClass(exp)) {
+                                J.FieldAccess fieldAccess = (J.FieldAccess) ((J.Assignment) exp).getAssignment();
+                                tpl.append("schema = @Schema(implementation = #{any()})");
+                                args.add(fieldAccess);
+                            } else {
+                                tpl.append("#{any()}");
+                                args.add(exp);
+                            }
+                        }
+                        anno = JavaTemplate.builder(tpl.toString())
+                                .imports(FQN_SCHEMA)
+                                .javaParser(JavaParser.fromJavaVersion().classpath("swagger-annotations"))
+                                .build()
+                                .apply(updateCursor(anno), annotation.getCoordinates().replaceArguments(), args.toArray());
+                        maybeAddImport(FQN_SCHEMA, false);
+                        return maybeAutoFormat(annotation, anno, ctx, getCursor().getParentTreeCursor());
+                    }
+
+                    private boolean isDataTypeClass(Expression exp) {
+                        return exp instanceof J.Assignment && ((J.Identifier) ((J.Assignment) exp).getVariable()).getSimpleName().equals("dataTypeClass");
+                    }
+                }
         );
     }
 }

--- a/src/main/java/org/openrewrite/openapi/swagger/MigrateApiImplicitParamDataTypeClass.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/MigrateApiImplicitParamDataTypeClass.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.openapi.swagger;
+
+import org.openrewrite.*;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MigrateApiImplicitParamDataTypeClass extends Recipe {
+    private static final String FQN_SCHEMA = "io.swagger.v3.oas.annotations.media.Schema";
+
+    @Override
+    public String getDisplayName() {
+        return "Migrate `@ApiImplicitParam(dataTypeClass=Foo.class)` to `@Parameter(schema=@Schema(implementation=Foo.class))`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrate `@ApiImplicitParam(dataTypeClass=Foo.class)` to `@Parameter(schema=@Schema(implementation=Foo.class))`.";
+    }
+
+    private boolean isDataTypeClass(Expression exp) {
+        return exp instanceof J.Assignment && ((J.Identifier) ((J.Assignment) exp).getVariable()).getSimpleName().equals("dataTypeClass");
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        // This recipe is after ChangeType recipe
+        return Preconditions.check(
+          new UsesMethod<>("io.swagger.annotations.ApiImplicitParam dataTypeClass()", false),
+          new JavaIsoVisitor<ExecutionContext>() {
+              @Override
+              public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  J.Annotation anno = super.visitAnnotation(annotation, ctx);
+
+                  StringBuilder tpl = new StringBuilder();
+                  List<Expression> args = new ArrayList<>();
+                  for (Expression exp : annotation.getArguments()) {
+                      if (!args.isEmpty()) {
+                          tpl.append(", ");
+                      }
+                      if (isDataTypeClass(exp)) {
+                          J.FieldAccess fieldAccess = (J.FieldAccess) ((J.Assignment) exp).getAssignment();
+                          tpl.append("schema = @Schema(implementation = #{any()})");
+                          args.add(fieldAccess);
+                      } else {
+                          tpl.append("#{any()}");
+                          args.add(exp);
+                      }
+                  }
+                  anno = JavaTemplate.builder(tpl.toString())
+                    .imports(FQN_SCHEMA)
+                    .build()
+                    .apply(updateCursor(annotation), annotation.getCoordinates().replaceArguments(), args.toArray());
+                  maybeAddImport(FQN_SCHEMA, false);
+                  return maybeAutoFormat(annotation, anno, ctx, getCursor().getParentTreeCursor());
+              }
+          }
+        );
+    }
+}

--- a/src/main/resources/META-INF/rewrite/swagger-2.yml
+++ b/src/main/resources/META-INF/rewrite/swagger-2.yml
@@ -190,6 +190,7 @@ recipeList:
   - org.openrewrite.java.RemoveAnnotationAttribute:
       annotationType: io.swagger.v3.oas.annotations.Parameter
       attributeName: allowMultiple
+  - org.openrewrite.openapi.swagger.MigrateApiImplicitParamDataTypeClass
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
@@ -17,13 +17,14 @@ package org.openrewrite.openapi.swagger;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import static org.openrewrite.java.Assertions.java;
 import org.openrewrite.java.JavaParser;
-import static org.openrewrite.maven.Assertions.pomXml;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import java.util.regex.Pattern;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.maven.Assertions.pomXml;
 
 class SwaggerToOpenAPITest implements RewriteTest {
     @Override

--- a/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
@@ -17,14 +17,14 @@ package org.openrewrite.openapi.swagger;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import static org.openrewrite.java.Assertions.java;
 import org.openrewrite.java.JavaParser;
+import static org.openrewrite.maven.Assertions.pomXml;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import java.util.regex.Pattern;
-
-import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.maven.Assertions.pomXml;
 
 class SwaggerToOpenAPITest implements RewriteTest {
     @Override
@@ -48,10 +48,10 @@ class SwaggerToOpenAPITest implements RewriteTest {
           java(
             """
               package example.org;
-              
+
               import io.swagger.annotations.ApiModel;
               import io.swagger.annotations.ApiModelProperty;
-              
+
               @ApiModel(value="ApiModelExampleValue", description="ApiModelExampleDescription")
               class Example {
                 @ApiModelProperty(value = "ApiModelPropertyExampleValue", position = 1)
@@ -60,9 +60,9 @@ class SwaggerToOpenAPITest implements RewriteTest {
               """,
             """
               package example.org;
-              
+
               import io.swagger.v3.oas.annotations.media.Schema;
-              
+
               @Schema(name="ApiModelExampleValue", description="ApiModelExampleDescription")
               class Example {
                 @Schema(description = "ApiModelPropertyExampleValue")
@@ -127,6 +127,35 @@ class SwaggerToOpenAPITest implements RewriteTest {
               .findFirst()
               .get()
               .group(1)))
+          )
+        );
+    }
+
+    @Test
+    void migrateApiImplicitParamDataTypeClass() {
+        rewriteRun(
+          recipeSpec -> recipeSpec.afterTypeValidationOptions(TypeValidation.none()),
+          //language=java
+          java(
+            """
+              import io.swagger.annotations.ApiImplicitParam;
+
+              class Example {
+                @ApiImplicitParam(name = "foo", value = "Foo object", required = true, dataTypeClass = Example.class)
+                public void create(Example foo) {
+                }
+              }
+              """,
+            """
+              import io.swagger.v3.oas.annotations.Parameter;
+              import io.swagger.v3.oas.annotations.media.Schema;
+
+              class Example {
+                @Parameter(name = "foo", description = "Foo object", required = true, schema = @Schema(implementation = Example.class))
+                public void create(Example foo) {
+                }
+              }
+              """
           )
         );
     }

--- a/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
@@ -22,7 +22,6 @@ import org.openrewrite.java.JavaParser;
 import static org.openrewrite.maven.Assertions.pomXml;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.TypeValidation;
 
 import java.util.regex.Pattern;
 
@@ -134,7 +133,6 @@ class SwaggerToOpenAPITest implements RewriteTest {
     @Test
     void migrateApiImplicitParamDataTypeClass() {
         rewriteRun(
-          recipeSpec -> recipeSpec.afterTypeValidationOptions(TypeValidation.none()),
           //language=java
           java(
             """


### PR DESCRIPTION
## What's changed?
Migrate `@ApiImplicitParam(dataTypeClass=Foo.class)` to `@Parameter(schema=@Schema(implementation=Foo.class))`

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
