### PR TITLE
Migrate @ApiModelProperty(dataType=) to @Schema(type=)

### DIFF
--- a/src/main/resources/META-INF/rewrite/swagger-2.yml
+++ b/src/main/resources/META-INF/rewrite/swagger-2.yml
@@ -230,6 +230,10 @@ recipeList:
   - org.openrewrite.java.RemoveAnnotationAttribute:
       annotationType: io.swagger.v3.oas.annotations.media.Schema
       attributeName: position
+  - org.openrewrite.java.ChangeAnnotationAttributeName:
+      annotationType: io.swagger.v3.oas.annotations.media.Schema
+      newAttributeName: type
+      oldAttributeName: dataType
 
 ---
 type: specs.openrewrite.org/v1beta/recipe


### PR DESCRIPTION
## What's changed?
MigrateApiModelPropertyToSchema doesn't handle the case that `@ApiModelProperty(dataType="foo")`. I convert it to `type` in this PR. Supposing the better idea is to remove `dataType` directly.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
