### PR TITLE
Migrate @SwaggerDefinition to @OpenAPIDefinition

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     testRuntimeOnly("io.swagger:swagger-annotations:1.6.13")
     testRuntimeOnly("io.swagger.core.v3:swagger-annotations:2.2.20")
+    testRuntimeOnly("jakarta.ws.rs:jakarta.ws.rs-api:3.1.0")
 
     testRuntimeOnly("org.gradle:gradle-tooling-api:latest.release")
 }

--- a/src/main/java/org/openrewrite/openapi/swagger/AnnotationUtils.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/AnnotationUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.openapi.swagger;
 
 import static java.util.Collections.emptyMap;

--- a/src/main/java/org/openrewrite/openapi/swagger/AnnotationUtils.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/AnnotationUtils.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.openapi.swagger;
 
+import lombok.experimental.UtilityClass;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 
@@ -23,7 +24,8 @@ import java.util.Map;
 
 import static java.util.Collections.emptyMap;
 
-public class AnnotationUtils {
+@UtilityClass
+class AnnotationUtils {
     public static Map<String, Expression> extractAnnotationArgumentAssignments(J.Annotation annotation) {
         if (annotation.getArguments() == null ||
                 annotation.getArguments().isEmpty() ||

--- a/src/main/java/org/openrewrite/openapi/swagger/AnnotationUtils.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/AnnotationUtils.java
@@ -1,0 +1,27 @@
+package org.openrewrite.openapi.swagger;
+
+import static java.util.Collections.emptyMap;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AnnotationUtils {
+    public static Map<String, Expression> extractAnnotationArgumentAssignments(J.Annotation annotation) {
+        if (annotation.getArguments() == null ||
+          annotation.getArguments().isEmpty() ||
+          annotation.getArguments().get(0) instanceof J.Empty) {
+            return emptyMap();
+        }
+        Map<String, Expression> map = new HashMap<>();
+        for (Expression expression : annotation.getArguments()) {
+            if (expression instanceof J.Assignment) {
+                J.Assignment a = (J.Assignment) expression;
+                String simpleName = ((J.Identifier) a.getVariable()).getSimpleName();
+                map.put(simpleName, a.getAssignment());
+            }
+        }
+        return map;
+    }
+}

--- a/src/main/java/org/openrewrite/openapi/swagger/AnnotationUtils.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/AnnotationUtils.java
@@ -15,18 +15,19 @@
  */
 package org.openrewrite.openapi.swagger;
 
-import static java.util.Collections.emptyMap;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Collections.emptyMap;
+
 public class AnnotationUtils {
     public static Map<String, Expression> extractAnnotationArgumentAssignments(J.Annotation annotation) {
         if (annotation.getArguments() == null ||
-          annotation.getArguments().isEmpty() ||
-          annotation.getArguments().get(0) instanceof J.Empty) {
+                annotation.getArguments().isEmpty() ||
+                annotation.getArguments().get(0) instanceof J.Empty) {
             return emptyMap();
         }
         Map<String, Expression> map = new HashMap<>();

--- a/src/main/java/org/openrewrite/openapi/swagger/MigrateApiToTag.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/MigrateApiToTag.java
@@ -89,7 +89,7 @@ public class MigrateApiToTag extends Recipe {
                     public J.@Nullable Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
                         J.Annotation ann = super.visitAnnotation(annotation, ctx);
                         if (apiMatcher.matches(ann)) {
-                            Map<String, Expression> annotationArgumentAssignments = extractAnnotationArgumentAssignments(ann);
+                            Map<String, Expression> annotationArgumentAssignments = AnnotationUtils.extractAnnotationArgumentAssignments(ann);
                             if (annotationArgumentAssignments.get("tags") != null) {
                                 // Remove @Api and add @Tag or @Tags at class level
                                 getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, FQN_API, annotationArgumentAssignments);
@@ -100,23 +100,6 @@ public class MigrateApiToTag extends Recipe {
                             doAfterVisit(new ChangeType(FQN_API, FQN_TAG, true).getVisitor());
                         }
                         return ann;
-                    }
-
-                    private Map<String, Expression> extractAnnotationArgumentAssignments(J.Annotation apiAnnotation) {
-                        if (apiAnnotation.getArguments() == null ||
-                            apiAnnotation.getArguments().isEmpty() ||
-                            apiAnnotation.getArguments().get(0) instanceof J.Empty) {
-                            return emptyMap();
-                        }
-                        Map<String, Expression> map = new HashMap<>();
-                        for (Expression expression : apiAnnotation.getArguments()) {
-                            if (expression instanceof J.Assignment) {
-                                J.Assignment a = (J.Assignment) expression;
-                                String simpleName = ((J.Identifier) a.getVariable()).getSimpleName();
-                                map.put(simpleName, a.getAssignment());
-                            }
-                        }
-                        return map;
                     }
 
                     @Override

--- a/src/main/java/org/openrewrite/openapi/swagger/MigrateApiToTag.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/MigrateApiToTag.java
@@ -27,11 +27,9 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 
@@ -42,31 +40,33 @@ public class MigrateApiToTag extends Recipe {
     private static final String FQN_TAGS = "io.swagger.v3.oas.annotations.tags.Tags";
 
     @Language("java")
-    private static final String TAGS_CLASS = "package io.swagger.v3.oas.annotations.tags;\n" +
-                                             "import java.lang.annotation.ElementType;\n" +
-                                             "import java.lang.annotation.Retention;\n" +
-                                             "import java.lang.annotation.RetentionPolicy;\n" +
-                                             "import java.lang.annotation.Target;\n" +
-                                             "@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})\n" +
-                                             "@Retention(RetentionPolicy.RUNTIME)\n" +
-                                             "public @interface Tags {\n" +
-                                             "    Tag[] value() default {};\n" +
-                                             "}";
+    private static final String TAGS_CLASS =
+            "package io.swagger.v3.oas.annotations.tags;\n" +
+            "import java.lang.annotation.ElementType;\n" +
+            "import java.lang.annotation.Retention;\n" +
+            "import java.lang.annotation.RetentionPolicy;\n" +
+            "import java.lang.annotation.Target;\n" +
+            "@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})\n" +
+            "@Retention(RetentionPolicy.RUNTIME)\n" +
+            "public @interface Tags {\n" +
+            "    Tag[] value() default {};\n" +
+            "}";
 
     @Language("java")
-    private static final String TAG_CLASS = "package io.swagger.v3.oas.annotations.tags;\n" +
-                                            "import java.lang.annotation.ElementType;\n" +
-                                            "import java.lang.annotation.Repeatable;\n" +
-                                            "import java.lang.annotation.Retention;\n" +
-                                            "import java.lang.annotation.RetentionPolicy;\n" +
-                                            "import java.lang.annotation.Target;\n" +
-                                            "@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})\n" +
-                                            "@Retention(RetentionPolicy.RUNTIME)\n" +
-                                            "@Repeatable(Tags.class)\n" +
-                                            "public @interface Tag {\n" +
-                                            "    String name();\n" +
-                                            "    String description() default \"\";\n" +
-                                            "}";
+    private static final String TAG_CLASS =
+            "package io.swagger.v3.oas.annotations.tags;\n" +
+            "import java.lang.annotation.ElementType;\n" +
+            "import java.lang.annotation.Repeatable;\n" +
+            "import java.lang.annotation.Retention;\n" +
+            "import java.lang.annotation.RetentionPolicy;\n" +
+            "import java.lang.annotation.Target;\n" +
+            "@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})\n" +
+            "@Retention(RetentionPolicy.RUNTIME)\n" +
+            "@Repeatable(Tags.class)\n" +
+            "public @interface Tag {\n" +
+            "    String name();\n" +
+            "    String description() default \"\";\n" +
+            "}";
 
     @Override
     public String getDisplayName() {

--- a/src/main/java/org/openrewrite/openapi/swagger/MigrateSwaggerDefinitionToOpenAPIDefinition.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/MigrateSwaggerDefinitionToOpenAPIDefinition.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.openapi.swagger;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.java.*;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class MigrateSwaggerDefinitionToOpenAPIDefinition extends Recipe {
+
+    private static final String FQN_SWAGGER_DEFINITION = "io.swagger.annotations.SwaggerDefinition";
+    private static final String FQN_OPENAPI_DEFINITION = "io.swagger.v3.oas.annotations.OpenAPIDefinition";
+    private static final String FQN_SERVER = "io.swagger.v3.oas.annotations.servers.Server";
+
+    @Override
+    public String getDisplayName() {
+        return "Migrate from `@SwaggerDefinition` to `@OpenAPIDefinition`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrate from `@SwaggerDefinition` to `@OpenAPIDefinition`.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+          new UsesType<>(FQN_SWAGGER_DEFINITION, false),
+          new JavaIsoVisitor<ExecutionContext>() {
+              private final AnnotationMatcher annotationMatcher = new AnnotationMatcher(FQN_SWAGGER_DEFINITION);
+
+              @Override
+              public J.@Nullable Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  J.Annotation ann = super.visitAnnotation(annotation, ctx);
+
+                  if (annotationMatcher.matches(ann)) {
+                      Map<String, Expression> args = AnnotationUtils.extractAnnotationArgumentAssignments(ann);
+
+                      StringBuilder tpl = new StringBuilder("@OpenAPIDefinition(\n");
+                      List<Object> tplArgs = new ArrayList<>();
+
+                      Expression basePath = args.get("basePath");
+                      Expression host = args.get("host");
+                      Expression schemes = args.get("schemes");
+                      String servers = "";
+                      if (basePath != null && host != null && schemes != null) {
+                          tpl.append("servers = {\n");
+                          for (Expression scheme : ((J.NewArray) schemes).getInitializer()) {
+                              if (!servers.isEmpty()) {
+                                  servers += ",\n";
+                              }
+                              String url = host.toString() + basePath;
+                              String schemeName = ((J.FieldAccess) scheme).getSimpleName();
+                              if ("HTTP".equals(schemeName)) {
+                                  servers += "@Server(url = \"http://" + url + "\")";
+                              } else if ("HTTPS".equals(schemeName)) {
+                                  servers += "@Server(url = \"https://" + url + "\")";
+                              }
+                          }
+                          tpl.append(servers);
+                          tpl.append("\n}");
+                      }
+
+                      if (args.containsKey("info")) {
+                          tpl.append(", \ninfo = #{any()}");
+                          tplArgs.add(args.get("info"));
+                      }
+                      tpl.append(")");
+
+                      ann = JavaTemplate.builder(tpl.toString())
+                        .imports(FQN_OPENAPI_DEFINITION, FQN_SERVER)
+                        .javaParser(JavaParser.fromJavaVersion().dependsOn(FQN_OPENAPI_DEFINITION, FQN_SERVER))
+                        .build()
+                        .apply(updateCursor(ann), ann.getCoordinates().replace(), tplArgs.toArray());
+                      maybeRemoveImport(FQN_SWAGGER_DEFINITION);
+                      maybeAddImport(FQN_OPENAPI_DEFINITION, false);
+                      maybeAddImport(FQN_SERVER, false);
+                      ann = maybeAutoFormat(annotation, ann, ctx);
+                  }
+
+                  return ann;
+              }
+          }
+        );
+    }
+}

--- a/src/main/java/org/openrewrite/openapi/swagger/MigrateSwaggerDefinitionToOpenAPIDefinition.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/MigrateSwaggerDefinitionToOpenAPIDefinition.java
@@ -16,7 +16,10 @@
 package org.openrewrite.openapi.swagger;
 
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.*;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.*;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.Expression;
@@ -45,75 +48,69 @@ public class MigrateSwaggerDefinitionToOpenAPIDefinition extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
-          new UsesType<>(FQN_SWAGGER_DEFINITION, false),
-          new JavaIsoVisitor<ExecutionContext>() {
-              private final AnnotationMatcher annotationMatcher = new AnnotationMatcher(FQN_SWAGGER_DEFINITION);
+                new UsesType<>(FQN_SWAGGER_DEFINITION, false),
+                new JavaIsoVisitor<ExecutionContext>() {
+                    private final AnnotationMatcher annotationMatcher = new AnnotationMatcher(FQN_SWAGGER_DEFINITION);
 
-              @Override
-              public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
-                  cu = super.visitCompilationUnit(cu, executionContext);
-                  return cu;
-              }
+                    @Override
+                    public J.@Nullable Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                        J.Annotation ann = super.visitAnnotation(annotation, ctx);
 
-              @Override
-              public J.@Nullable Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
-                  J.Annotation ann = super.visitAnnotation(annotation, ctx);
+                        if (annotationMatcher.matches(ann)) {
+                            Map<String, Expression> args = AnnotationUtils.extractAnnotationArgumentAssignments(ann);
 
-                  if (annotationMatcher.matches(ann)) {
-                      Map<String, Expression> args = AnnotationUtils.extractAnnotationArgumentAssignments(ann);
+                            StringBuilder tpl = new StringBuilder("@OpenAPIDefinition(\n");
+                            List<Expression> tplArgs = new ArrayList<>();
+                            List<String> parts = new ArrayList<>();
 
-                      StringBuilder tpl = new StringBuilder("@OpenAPIDefinition(\n");
-                      List<Expression> tplArgs = new ArrayList<>();
-                      List<String> parts = new ArrayList<>();
+                            Expression basePath = args.get("basePath");
+                            Expression host = args.get("host");
+                            Expression schemes = args.get("schemes");
+                            String servers = "";
+                            if (basePath != null && host != null && schemes != null) {
+                                tpl.append("servers = {\n");
+                                if (schemes instanceof J.FieldAccess) {
+                                    servers += "@Server(url = \"" + ((J.FieldAccess) schemes).getSimpleName().toLowerCase() + "://" + host + basePath + "\")";
+                                } else if (schemes instanceof J.NewArray) {
+                                    for (Expression scheme : ((J.NewArray) schemes).getInitializer()) {
+                                        if (!servers.isEmpty()) {
+                                            servers += ",\n";
+                                        }
+                                        String schemeName = ((J.FieldAccess) scheme).getSimpleName().toLowerCase();
+                                        servers += "@Server(url = \"" + schemeName + "://" + host + basePath + "\")";
+                                    }
+                                }
+                                servers += "\n}";
+                                parts.add(servers);
+                            }
 
-                      Expression basePath = args.get("basePath");
-                      Expression host = args.get("host");
-                      Expression schemes = args.get("schemes");
-                      String servers = "";
-                      if (basePath != null && host != null && schemes != null) {
-                          tpl.append("servers = {\n");
-                          if (schemes instanceof J.FieldAccess) {
-                              servers += "@Server(url = \"" + ((J.FieldAccess) schemes).getSimpleName().toLowerCase() + "://" + host + basePath + "\")";
-                          } else if (schemes instanceof J.NewArray) {
-                              for (Expression scheme : ((J.NewArray) schemes).getInitializer()) {
-                                  if (!servers.isEmpty()) {
-                                      servers += ",\n";
-                                  }
-                                  String schemeName = ((J.FieldAccess) scheme).getSimpleName().toLowerCase();
-                                  servers += "@Server(url = \"" + schemeName + "://" + host + basePath + "\")";
-                              }
-                          }
-                          servers += "\n}";
-                          parts.add(servers);
-                      }
+                            args.remove("basePath");
+                            args.remove("host");
+                            args.remove("schemes");
+                            args.remove("produces");
+                            args.remove("consumes");
+                            for (Map.Entry<String, Expression> arg : args.entrySet()) {
+                                parts.add(arg.getKey() + " = #{any()}");
+                                tplArgs.add(arg.getValue());
+                            }
+                            tpl.append(String.join(",\n", parts));
+                            tpl.append("\n)");
 
-                      args.remove("basePath");
-                      args.remove("host");
-                      args.remove("schemes");
-                      args.remove("produces");
-                      args.remove("consumes");
-                      for (Map.Entry<String, Expression> arg : args.entrySet()) {
-                          parts.add(arg.getKey() + " = #{any()}");
-                          tplArgs.add(arg.getValue());
-                      }
-                      tpl.append(String.join(",\n", parts));
-                      tpl.append("\n)");
+                            ann = JavaTemplate.builder(tpl.toString())
+                                    .imports(FQN_OPENAPI_DEFINITION, FQN_SERVER)
+                                    .javaParser(JavaParser.fromJavaVersion().classpath("swagger-annotations"))
+                                    .build()
+                                    .apply(updateCursor(ann), ann.getCoordinates().replace(), tplArgs.toArray());
+                            maybeRemoveImport(FQN_SWAGGER_DEFINITION);
+                            maybeAddImport(FQN_OPENAPI_DEFINITION, false);
+                            maybeAddImport(FQN_SERVER, false);
+                            ann = maybeAutoFormat(annotation, ann, ctx);
+                        }
 
-                      ann = JavaTemplate.builder(tpl.toString())
-                        .imports(FQN_OPENAPI_DEFINITION, FQN_SERVER)
-                        .javaParser(JavaParser.fromJavaVersion().classpath("swagger-annotations"))
-                        .build()
-                        .apply(updateCursor(ann), ann.getCoordinates().replace(), tplArgs.toArray());
-                      maybeRemoveImport(FQN_SWAGGER_DEFINITION);
-                      maybeAddImport(FQN_OPENAPI_DEFINITION, false);
-                      maybeAddImport(FQN_SERVER, false);
-                      ann = maybeAutoFormat(annotation, ann, ctx);
-                  }
-
-                  doAfterVisit(new RemoveUnusedImports().getVisitor());
-                  return ann;
-              }
-          }
+                        doAfterVisit(new RemoveUnusedImports().getVisitor());
+                        return ann;
+                    }
+                }
         );
     }
 }

--- a/src/main/java/org/openrewrite/openapi/swagger/MigrateSwaggerDefinitionToOpenAPIDefinition.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/MigrateSwaggerDefinitionToOpenAPIDefinition.java
@@ -69,13 +69,8 @@ public class MigrateSwaggerDefinitionToOpenAPIDefinition extends Recipe {
                               if (!servers.isEmpty()) {
                                   servers += ",\n";
                               }
-                              String url = host.toString() + basePath;
-                              String schemeName = ((J.FieldAccess) scheme).getSimpleName();
-                              if ("HTTP".equals(schemeName)) {
-                                  servers += "@Server(url = \"http://" + url + "\")";
-                              } else if ("HTTPS".equals(schemeName)) {
-                                  servers += "@Server(url = \"https://" + url + "\")";
-                              }
+                              String schemeName = ((J.FieldAccess) scheme).getSimpleName().toLowerCase();
+                              servers += "@Server(url = \"" + schemeName + "://" + host + basePath + "\")";
                           }
                           tpl.append(servers);
                           tpl.append("\n}");

--- a/src/main/resources/META-INF/rewrite/swagger-2.yml
+++ b/src/main/resources/META-INF/rewrite/swagger-2.yml
@@ -44,6 +44,9 @@ recipeList:
       oldFullyQualifiedTypeName: io.swagger.annotations.Tag
       newFullyQualifiedTypeName: io.swagger.v3.oas.annotations.tags.Tag
   - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: io.swagger.annotations.Info
+      newFullyQualifiedTypeName: io.swagger.v3.oas.annotations.info.Info
+  - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: springfox.documentation.annotations.ApiIgnore
       newFullyQualifiedTypeName: io.swagger.v3.oas.annotations.Hidden
   - org.openrewrite.openapi.swagger.MigrateApiOperationToOperation
@@ -53,6 +56,7 @@ recipeList:
   - org.openrewrite.openapi.swagger.MigrateApiParamToParameter
   - org.openrewrite.openapi.swagger.MigrateApiModelPropertyToSchema
   - org.openrewrite.openapi.swagger.MigrateApiModelToSchema
+  - org.openrewrite.openapi.swagger.MigrateSwaggerDefinitionToOpenAPIDefinition
 
 # todo add swagger-core to common-dependencies
 

--- a/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
@@ -17,14 +17,14 @@ package org.openrewrite.openapi.swagger;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import static org.openrewrite.java.Assertions.java;
 import org.openrewrite.java.JavaParser;
-import static org.openrewrite.maven.Assertions.pomXml;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.TypeValidation;
 
 import java.util.regex.Pattern;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.maven.Assertions.pomXml;
 
 class SwaggerToOpenAPITest implements RewriteTest {
     @Override
@@ -47,8 +47,6 @@ class SwaggerToOpenAPITest implements RewriteTest {
           //language=java
           java(
             """
-              package example.org;
-
               import io.swagger.annotations.ApiModel;
               import io.swagger.annotations.ApiModelProperty;
 
@@ -59,8 +57,6 @@ class SwaggerToOpenAPITest implements RewriteTest {
               }
               """,
             """
-              package example.org;
-
               import io.swagger.v3.oas.annotations.media.Schema;
 
               @Schema(name="ApiModelExampleValue", description="ApiModelExampleDescription")
@@ -194,13 +190,13 @@ class SwaggerToOpenAPITest implements RewriteTest {
               class Example {
               }
               """
-          ));
+          )
+        );
     }
 
     @Test
     void migrateSwaggerDefinitionsToOpenAPIDefinitionMultipleSchema() {
         rewriteRun(
-//          recipeSpec -> recipeSpec.afterTypeValidationOptions(TypeValidation.none()),
           //language=java
           java(
             """
@@ -233,6 +229,7 @@ class SwaggerToOpenAPITest implements RewriteTest {
               class Example {
               }
               """
-          ));
+          )
+        );
     }
 }

--- a/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
@@ -17,15 +17,14 @@ package org.openrewrite.openapi.swagger;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import static org.openrewrite.java.Assertions.java;
 import org.openrewrite.java.JavaParser;
+import static org.openrewrite.maven.Assertions.pomXml;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import java.util.regex.Pattern;
-
-import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.maven.Assertions.pomXml;
-import org.openrewrite.test.TypeValidation;
 
 class SwaggerToOpenAPITest implements RewriteTest {
     @Override

--- a/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
@@ -48,10 +48,10 @@ class SwaggerToOpenAPITest implements RewriteTest {
           java(
             """
               package example.org;
-              
+
               import io.swagger.annotations.ApiModel;
               import io.swagger.annotations.ApiModelProperty;
-              
+
               @ApiModel(value="ApiModelExampleValue", description="ApiModelExampleDescription")
               class Example {
                 @ApiModelProperty(value = "ApiModelPropertyExampleValue", position = 1)
@@ -60,9 +60,9 @@ class SwaggerToOpenAPITest implements RewriteTest {
               """,
             """
               package example.org;
-              
+
               import io.swagger.v3.oas.annotations.media.Schema;
-              
+
               @Schema(name="ApiModelExampleValue", description="ApiModelExampleDescription")
               class Example {
                 @Schema(description = "ApiModelPropertyExampleValue")
@@ -129,5 +129,48 @@ class SwaggerToOpenAPITest implements RewriteTest {
               .group(1)))
           )
         );
+    }
+
+    @Test
+    void migrateSwaggerDefinitionsToOpenAPIDefinition() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import io.swagger.annotations.Info;
+              import io.swagger.annotations.SwaggerDefinition;
+              import jakarta.ws.rs.core.MediaType;
+
+              @SwaggerDefinition(
+                basePath = "/api",
+                host="example.com",
+                info = @Info(title = "Example", version = "V1.0"),
+                consumes = { MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML },
+                produces = { MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML },
+                schemes = { SwaggerDefinition.Scheme.HTTP, SwaggerDefinition.Scheme.HTTPS })
+              class Example {
+              }
+              """,
+            """
+              import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+              import io.swagger.v3.oas.annotations.info.Info;
+              import io.swagger.v3.oas.annotations.servers.Server;
+              import jakarta.ws.rs.core.MediaType;
+
+              import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+              import io.swagger.v3.oas.annotations.info.Info;
+              import io.swagger.v3.oas.annotations.servers.Server;
+              import jakarta.ws.rs.core.MediaType;
+
+              @OpenAPIDefinition(
+                      servers = {
+                              @Server(url = "http://example.com/api"),
+                              @Server(url = "https://example.com/api")
+                      },
+                      info = @Info(title = "Example", version = "V1.0"))
+              class Example {
+              }
+              """
+          ));
     }
 }

--- a/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
@@ -25,6 +25,7 @@ import java.util.regex.Pattern;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.maven.Assertions.pomXml;
+import org.openrewrite.test.TypeValidation;
 
 class SwaggerToOpenAPITest implements RewriteTest {
     @Override
@@ -134,6 +135,7 @@ class SwaggerToOpenAPITest implements RewriteTest {
     @Test
     void migrateSwaggerDefinitionsToOpenAPIDefinition() {
         rewriteRun(
+          recipeSpec -> recipeSpec.afterTypeValidationOptions(TypeValidation.none()),
           //language=java
           java(
             """
@@ -152,11 +154,6 @@ class SwaggerToOpenAPITest implements RewriteTest {
               }
               """,
             """
-              import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-              import io.swagger.v3.oas.annotations.info.Info;
-              import io.swagger.v3.oas.annotations.servers.Server;
-              import jakarta.ws.rs.core.MediaType;
-
               import io.swagger.v3.oas.annotations.OpenAPIDefinition;
               import io.swagger.v3.oas.annotations.info.Info;
               import io.swagger.v3.oas.annotations.servers.Server;

--- a/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
@@ -163,7 +163,8 @@ class SwaggerToOpenAPITest implements RewriteTest {
                               @Server(url = "http://example.com/api"),
                               @Server(url = "https://example.com/api")
                       },
-                      info = @Info(title = "Example", version = "V1.0"))
+                      info = @Info(title = "Example", version = "V1.0")
+              )
               class Example {
               }
               """


### PR DESCRIPTION
## What's changed?
This recipe migrate `@SwaggerDefinition` to `@OpenAPIDefinition`
- Combines `basePath`, `host` and `schemes` into `servers`
- Drop `consumes` and `produces`, leave the others untouched
- Change `io.swagger.annotations.Info` to `io.swagger.v3.oas.annotations.info.Info`

Ref: https://support.intershop.com/kb/index.php/Display/2914L4

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
