### PR TITLE
Fix MigrateApiImplicitParam syntax error when args after schema

### DIFF
--- a/src/main/java/org/openrewrite/openapi/swagger/MigrateApiImplicitParam.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/MigrateApiImplicitParam.java
@@ -62,16 +62,17 @@ public class MigrateApiImplicitParam extends Recipe {
 
                   StringBuilder tpl = new StringBuilder();
                   StringBuilder schemaTpl = new StringBuilder();
+                  List<Expression> schemaArgs = new ArrayList<>();
                   List<Expression> args = new ArrayList<>();
                   for (Expression exp : anno.getArguments()) {
                       if (isDataTypeClass(exp)) {
                           Expression expression = ((J.Assignment) exp).getAssignment();
                           addSchema(schemaTpl, "implementation");
-                          args.add(expression);
+                          schemaArgs.add(expression);
                       } else if (isDefaultValue(exp)) {
                           Expression expression = ((J.Assignment) exp).getAssignment();
                           addSchema(schemaTpl, "defaultValue");
-                          args.add(expression);
+                          schemaArgs.add(expression);
                       } else {
                           tpl.append("#{any()}, ");
                           args.add(exp);
@@ -86,6 +87,7 @@ public class MigrateApiImplicitParam extends Recipe {
                       }
                       schemaTpl.append(")");
                       tpl.append(", ").append(schemaTpl);
+                      args.addAll(schemaArgs);
                   }
                   anno = JavaTemplate.builder(tpl.toString())
                     .imports(FQN_SCHEMA)

--- a/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
@@ -136,7 +136,7 @@ class SwaggerToOpenAPITest implements RewriteTest {
               import io.swagger.annotations.ApiImplicitParam;
 
               class Example {
-                @ApiImplicitParam(name = "foo", value = "Foo object", required = true, dataTypeClass = Example.class, defaultValue = "example")
+                @ApiImplicitParam(name = "Foo", value = "Bar", required = true, allowEmptyValue = false, paramType = "Hi", dataTypeClass = String.class, example = "Example")
                 public void create(Example foo) {
                 }
               }
@@ -146,7 +146,7 @@ class SwaggerToOpenAPITest implements RewriteTest {
               import io.swagger.v3.oas.annotations.media.Schema;
 
               class Example {
-                @Parameter(name = "foo", description = "Foo object", required = true, schema = @Schema(implementation = Example.class, defaultValue = "example"))
+                @Parameter(name = "Foo", description = "Bar", required = true, allowEmptyValue = false, example = "Example", schema = @Schema(implementation = String.class))
                 public void create(Example foo) {
                 }
               }


### PR DESCRIPTION
## What's changed?
Fix MigrateApiImplicitParam syntax error when args after schema.
For example, in UT, `example` is after `dataTypeClass`(will be migrated to `schema`), the recipe will produce syntax error.


### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
