### PR TITLE
Remove direct change type from Swagger Tag to OpenAPI Tag

### DIFF
--- a/src/main/resources/META-INF/rewrite/swagger-2.yml
+++ b/src/main/resources/META-INF/rewrite/swagger-2.yml
@@ -41,9 +41,6 @@ recipeList:
   # https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Annotations
   # https://springdoc.org/#migrating-from-springfox
   - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: io.swagger.annotations.Tag
-      newFullyQualifiedTypeName: io.swagger.v3.oas.annotations.tags.Tag
-  - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: io.swagger.annotations.Info
       newFullyQualifiedTypeName: io.swagger.v3.oas.annotations.info.Info
   - org.openrewrite.java.ChangeType:


### PR DESCRIPTION
Direct changing `io.swagger.annotations.Tag` to `io.swagger.v3.oas.annotations.tags.Tag` is incorrect. 
They are structurally and semantically different.

`io.swagger.annotations.Tag` used inside `@SwaggerDefinition`:
```
@SwaggerDefinition(
    tags = {
        @Tag(name = "User", description = "User operations")
    }
)
```
While `io.swagger.v3.oas.annotations.tags.Tag` is a class-level annotation:
```
@Tag(name = "User", description = "User operations")
@RestController
public class UserController { ... }
```

There should be a custom recipe to migrate Swagger tags defined in a `@SwaggerDefinition` to OpenAPI tags