### PR TITLE
Added `ConvertApiResponseToContent` recipe

### DIFF
--- a/src/main/java/org/openrewrite/openapi/swagger/ConvertApiResponseToContent.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/ConvertApiResponseToContent.java
@@ -77,7 +77,7 @@ public class ConvertApiResponseToContent extends Recipe {
                                         .imports(FQN_CONTENT, FQN_SCHEMA)
                                         .javaParser(JavaParser.fromJavaVersion().classpath("swagger-annotations"))
                                         .build()
-                                        .apply(updateCursor(an), an.getCoordinates().replaceArguments(), ListUtils.concat(maybeArgsWithoutResponse, contentClass.get()).toArray());
+                                        .apply(getCursor(), an.getCoordinates().replaceArguments(), ListUtils.concat(maybeArgsWithoutResponse, contentClass.get()).toArray());
                                 maybeAddImport(FQN_CONTENT);
                                 maybeAddImport(FQN_SCHEMA);
                                 return maybeAutoFormat(annotation, an, ctx, getCursor().getParentTreeCursor());

--- a/src/main/java/org/openrewrite/openapi/swagger/ConvertApiResponseToContent.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/ConvertApiResponseToContent.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.openapi.swagger;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ConvertApiResponseToContent extends Recipe {
+
+    private static final AnnotationMatcher ANNOTATION_MATCHER = new AnnotationMatcher("@io.swagger.v3.oas.annotations.responses.ApiResponse");
+    private static final String FQN_CONTENT = "io.swagger.v3.oas.annotations.media.Content";
+    private static final String FQN_SCHEMA = "io.swagger.v3.oas.annotations.media.Schema";
+
+    @Override
+    public String getDisplayName() {
+        return "Convert API response to content annotation";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Convert API response to content annotation";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new UsesType<>("io.swagger.v3.oas.annotations.responses.ApiResponse", true),
+                new JavaIsoVisitor<ExecutionContext>() {
+                    @Override
+                    public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                        J.Annotation an = super.visitAnnotation(annotation, ctx);
+                        if (ANNOTATION_MATCHER.matches(an) && an.getArguments() != null) {
+                            AtomicReference<J.FieldAccess> contentClass = new AtomicReference<>();
+                            List<Expression> maybeArgsWithoutResponse = ListUtils.map(an.getArguments(), arg -> {
+                                if (arg instanceof J.Assignment) {
+                                    J.Assignment assignment = (J.Assignment) arg;
+                                    if (assignment.getVariable() instanceof J.Identifier &&
+                                            "response".equals(((J.Identifier) assignment.getVariable()).getSimpleName()) &&
+                                            assignment.getAssignment() instanceof J.FieldAccess) {
+                                        contentClass.set((J.FieldAccess) assignment.getAssignment());
+                                        return null;
+                                    }
+                                }
+                                return arg;
+                            });
+
+                            if (an.getArguments().size() > maybeArgsWithoutResponse.size()) {
+                                String arguments = StringUtils.repeat("#{any()}, ", maybeArgsWithoutResponse.size());
+                                an = JavaTemplate.builder(arguments + "content = @Content(mediaType = \"application/json\", schema = @Schema(implementation = #{any()}))")
+                                        .imports(FQN_CONTENT, FQN_SCHEMA)
+                                        .javaParser(JavaParser.fromJavaVersion().classpath("swagger-annotations"))
+                                        .build()
+                                        .apply(updateCursor(an), an.getCoordinates().replaceArguments(), ListUtils.concat(maybeArgsWithoutResponse, contentClass.get()).toArray());
+                                maybeAddImport(FQN_CONTENT);
+                                maybeAddImport(FQN_SCHEMA);
+                                return maybeAutoFormat(annotation, an, ctx, getCursor().getParentTreeCursor());
+                            }
+                        }
+                        return an;
+                    }
+                });
+    }
+}

--- a/src/main/resources/META-INF/rewrite/swagger-2.yml
+++ b/src/main/resources/META-INF/rewrite/swagger-2.yml
@@ -152,7 +152,7 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.openapi.swagger.MigrateApiResponsesToApiResponses
 displayName: Migrate from `@ApiResponses` to `@ApiResponses`
 description: Changes the namespace of the `@ApiResponses` and `@ApiResponse` annotations and converts its attributes
-  (ex. code -> responseCode, message -> description).
+  (ex. code -> responseCode, message -> description, response -> content).
 tags:
   - swagger
   - openapi
@@ -172,6 +172,7 @@ recipeList:
       oldAttributeName: "message"
       newAttributeName: "description"
   - org.openrewrite.openapi.swagger.ConvertApiResponseCodesToStrings
+  - org.openrewrite.openapi.swagger.ConvertApiResponseToContent
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
@@ -35,7 +35,8 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
     void convertApiResponseCodesToStrings() {
         //language=java
         rewriteRun(
-          java("""
+          java(
+            """
             class ResponseEntity<T> {}
             class User {}
             """),
@@ -68,7 +69,8 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
     void noChangeOnAlreadyConverted() {
         //language=java
         rewriteRun(
-          java("""
+          java(
+            """
             class ResponseEntity<T> {}
             class User {}
             """),

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
@@ -82,7 +82,7 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
 
               class A {
                   @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = User.class)))
-                  ResponseEntity<User> method() {}
+                  ResponseEntity<User> method() { return null; }
               }
               """
           )

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
@@ -35,8 +35,10 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
     void convertApiResponseCodesToStrings() {
         //language=java
         rewriteRun(
-          java("""
-            class ResponseEntity<T> {}
+          java(
+                """
+            """
+          ),
             class User {}
             """),
           java(
@@ -68,8 +70,10 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
     void noChangeOnAlreadyConverted() {
         //language=java
         rewriteRun(
-          java("""
-            class ResponseEntity<T> {}
+          java(
+                """
+            """
+          ),
             class User {}
             """),
           java(

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-class ConvertApiResponseCodesToStringsTest implements RewriteTest {
+class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResources("org.openrewrite.openapi.swagger.MigrateApiResponsesToApiResponses")
@@ -33,23 +33,31 @@ class ConvertApiResponseCodesToStringsTest implements RewriteTest {
     @Test
     @DocumentExample
     void convertApiResponseCodesToStrings() {
+        //language=java
         rewriteRun(
-          //language=java
+          java("""
+            class ResponseEntity<T> {}
+            class User {}
+            """),
           java(
             """
               import io.swagger.annotations.ApiResponse;
-              
+              import org.springframework.http.ResponseEntity;
+
               class A {
-                  @ApiResponse(code = 200, message = "OK")
-                  void method() {}
+                  @ApiResponse(code = 200, message = "OK", response = User.class)
+                  ResponseEntity<User> method() { return null; }
               }
               """,
             """
+              import io.swagger.v3.oas.annotations.media.Content;
+              import io.swagger.v3.oas.annotations.media.Schema;
               import io.swagger.v3.oas.annotations.responses.ApiResponse;
-              
+              import org.springframework.http.ResponseEntity;
+
               class A {
-                  @ApiResponse(responseCode = "200", description = "OK")
-                  void method() {}
+                  @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = User.class)))
+                  ResponseEntity<User> method() { return null; }
               }
               """
           )
@@ -58,15 +66,21 @@ class ConvertApiResponseCodesToStringsTest implements RewriteTest {
 
     @Test
     void noChangeOnAlreadyConverted() {
+        //language=java
         rewriteRun(
-          //language=java
+          java("""
+            class ResponseEntity<T> {}
+            class User {}
+            """),
           java(
             """
+              import io.swagger.v3.oas.annotations.media.Content;
+              import io.swagger.v3.oas.annotations.media.Schema;
               import io.swagger.v3.oas.annotations.responses.ApiResponse;
-              
+
               class A {
-                  @ApiResponse(responseCode = "200", description = "OK")
-                  void method() {}
+                  @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = User.class)))
+                  ResponseEntity<User> method() {}
               }
               """
           )

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
@@ -35,10 +35,8 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
     void convertApiResponseCodesToStrings() {
         //language=java
         rewriteRun(
-          java(
-                """
-            """
-          ),
+          java("""
+            class ResponseEntity<T> {}
             class User {}
             """),
           java(
@@ -70,10 +68,8 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
     void noChangeOnAlreadyConverted() {
         //language=java
         rewriteRun(
-          java(
-                """
-            """
-          ),
+          java("""
+            class ResponseEntity<T> {}
             class User {}
             """),
           java(

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
@@ -39,7 +39,8 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
             """
             class ResponseEntity<T> {}
             class User {}
-            """),
+            """
+          ),
           java(
             """
               import io.swagger.annotations.ApiResponse;
@@ -73,7 +74,8 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
             """
             class ResponseEntity<T> {}
             class User {}
-            """),
+            """
+          ),
           java(
             """
               import io.swagger.v3.oas.annotations.media.Content;


### PR DESCRIPTION
## What's changed?
The `@ApiResponse(response = User.class)` is now properly replaced by `@ApiResponse(content = @Content(mediaType = "application/json", schema = @Schema(implementation = User.class))),`.

## What's your motivation?
Migration was not complete without it. See also [Migration from Swagger 2 to Swagger 3 (OpenAPI 3)](https://medium.com/@patilparesh028/migration-from-swagger-2-to-swagger-3-openapi-3-da2db4851d87).

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
