### PR TITLE
update `ConvertApiResponseToContent` to migrate `responseContainer` as well

### DIFF
--- a/src/main/java/org/openrewrite/openapi/swagger/ConvertApiResponseToContent.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/ConvertApiResponseToContent.java
@@ -104,7 +104,7 @@ public class ConvertApiResponseToContent extends Recipe {
 							);
 						// 2) map case: wrap Schema in Schema
 						} else if ("Map".equals(type)) {
-							inner = "schema = @Schema(type = \"object\", additionalProperties = @Schema(implementation = #{any()})))";
+							inner = "schema = @Schema(type = \"object\", additionalPropertiesSchema = #{any()}))";
 						// 3) absent responseContainer case
 						} else {
 							inner = "schema = @Schema(implementation = #{any()}))";

--- a/src/main/java/org/openrewrite/openapi/swagger/ConvertApiResponseToContent.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/ConvertApiResponseToContent.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.openapi.swagger;
 
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -29,8 +30,6 @@ import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -39,7 +38,7 @@ public class ConvertApiResponseToContent extends Recipe {
     private static final AnnotationMatcher ANNOTATION_MATCHER = new AnnotationMatcher("@io.swagger.v3.oas.annotations.responses.ApiResponse");
     private static final String FQN_CONTENT = "io.swagger.v3.oas.annotations.media.Content";
     private static final String FQN_SCHEMA = "io.swagger.v3.oas.annotations.media.Schema";
-	private static final String FQN_ARRAYSCHEMA = "io.swagger.v3.oas.annotations.media.ArraySchema";
+    private static final String FQN_ARRAYSCHEMA = "io.swagger.v3.oas.annotations.media.ArraySchema";
 
     @Override
     public String getDisplayName() {
@@ -56,81 +55,71 @@ public class ConvertApiResponseToContent extends Recipe {
         return Preconditions.check(
                 new UsesType<>("io.swagger.v3.oas.annotations.responses.ApiResponse", true),
                 new JavaIsoVisitor<ExecutionContext>() {
-					@Override
-					public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
-						J.Annotation an = super.visitAnnotation(annotation, ctx);
-						if (!ANNOTATION_MATCHER.matches(an) || an.getArguments() == null) {
-							return an;
-						}
-						AtomicReference<J.FieldAccess> contentClass = new AtomicReference<>();
-						AtomicReference<J.Literal> containerType = new AtomicReference<>();
+                    @Override
+                    public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                        J.Annotation an = super.visitAnnotation(annotation, ctx);
+                        if (!ANNOTATION_MATCHER.matches(an) || an.getArguments() == null) {
+                            return an;
+                        }
+                        AtomicReference<J.FieldAccess> contentClass = new AtomicReference<>();
+                        AtomicReference<J.@Nullable Literal> containerType = new AtomicReference<>();
 
-						List<Expression> maybeArgsWithoutResponse = ListUtils.map(an.getArguments(), arg -> {
-							if (!(arg instanceof J.Assignment)) {
-								return arg;
-							}
-							J.Assignment assign = (J.Assignment) arg;
-							if (!(assign.getVariable() instanceof J.Identifier)) {
-								return arg;
-							}
-							String name = ((J.Identifier) assign.getVariable()).getSimpleName();
-							Expression assignment = assign.getAssignment();
-							if ("response".equals(name) && assignment instanceof J.FieldAccess) {
-								contentClass.set((J.FieldAccess) assignment);
-								return null;
-							}
-							if ("responseContainer".equals(name) && assignment instanceof J.Literal) {
-								containerType.set((J.Literal) assignment);
-								return null;
-							}
-							return arg;
-						});
+                        List<Expression> maybeArgsWithoutResponse = ListUtils.map(an.getArguments(), arg -> {
+                            if (!(arg instanceof J.Assignment)) {
+                                return arg;
+                            }
+                            J.Assignment assign = (J.Assignment) arg;
+                            if (!(assign.getVariable() instanceof J.Identifier)) {
+                                return arg;
+                            }
+                            String name = ((J.Identifier) assign.getVariable()).getSimpleName();
+                            Expression assignment = assign.getAssignment();
+                            if ("response".equals(name) && assignment instanceof J.FieldAccess) {
+                                contentClass.set((J.FieldAccess) assignment);
+                                return null;
+                            }
+                            if ("responseContainer".equals(name) && assignment instanceof J.Literal) {
+                                containerType.set((J.Literal) assignment);
+                                return null;
+                            }
+                            return arg;
+                        });
 
-						if (maybeArgsWithoutResponse.size() >= an.getArguments().size()) {
-							return an;
-						}
-						String arguments = StringUtils.repeat("#{any()}, ", maybeArgsWithoutResponse.size());
-						String inner;
-						String type = containerType.get() != null ? containerType.get().toString() : null;
-						List<String> imports = new ArrayList<>();
-						imports.add(FQN_CONTENT);
-						imports.add(FQN_SCHEMA);
-						// 1) list/set case: wrap in ArraySchema
-						if (Arrays.asList("List", "Set").contains(type)) {
-							imports.add(FQN_ARRAYSCHEMA);
-							inner = String.format(
-								"array = @ArraySchema(uniqueItems = %b, schema = @Schema(implementation = #{any()})))",
-								"Set".equals(type)
-							);
-						// 2) map case: wrap Schema in Schema
-						} else if ("Map".equals(type)) {
-							inner = "schema = @Schema(type = \"object\", additionalPropertiesSchema = #{any()}))";
-						// 3) absent responseContainer case
-						} else {
-							inner = "schema = @Schema(implementation = #{any()}))";
-						}
-						String tpl = "content = @Content(mediaType = \"application/json\", " + inner;
-						an = JavaTemplate.builder(arguments + tpl)
-							.imports(imports.toArray(new String[0]))
-							.javaParser(
-								JavaParser.fromJavaVersion()
-									.classpath("swagger-annotations")
-							)
-							.build()
-							.apply(
-								getCursor(),
-								an.getCoordinates().replaceArguments(),
-								ListUtils.concat(maybeArgsWithoutResponse, contentClass.get()).toArray()
-							);
-						maybeAddImport(FQN_CONTENT);
-						maybeAddImport(FQN_SCHEMA);
-						if (imports.contains(FQN_ARRAYSCHEMA)) {
-							maybeAddImport(FQN_ARRAYSCHEMA);
-						}
+                        if (maybeArgsWithoutResponse.size() >= an.getArguments().size()) {
+                            return an;
+                        }
+                        String inner;
+                        String type = containerType.get() != null ? containerType.get().toString() : null;
+                        // 1) list/set case: wrap in ArraySchema
+                        if ("List".equals(type) || "Set".equals(type)) {
+                            inner = String.format(
+                                    "array = @ArraySchema(uniqueItems = %b, schema = @Schema(implementation = #{any()})))",
+                                    "Set".equals(type)
+                            );
+                            // 2) map case: wrap Schema in Schema
+                        } else if ("Map".equals(type)) {
+                            inner = "schema = @Schema(type = \"object\", additionalPropertiesSchema = #{any()}))";
+                            // 3) absent responseContainer case
+                        } else {
+                            inner = "schema = @Schema(implementation = #{any()}))";
+                        }
+                        String arguments = StringUtils.repeat("#{any()}, ", maybeArgsWithoutResponse.size());
+                        an = JavaTemplate.builder(arguments + "content = @Content(mediaType = \"application/json\", " + inner)
+                                .imports("io.swagger.v3.oas.annotations.media.*")
+                                .javaParser(JavaParser.fromJavaVersion().classpath("swagger-annotations"))
+                                .build()
+                                .apply(
+                                        getCursor(),
+                                        an.getCoordinates().replaceArguments(),
+                                        ListUtils.concat(maybeArgsWithoutResponse, contentClass.get()).toArray()
+                                );
+                        maybeAddImport(FQN_CONTENT);
+                        maybeAddImport(FQN_SCHEMA);
+                        maybeAddImport(FQN_ARRAYSCHEMA);
 
-						return maybeAutoFormat(annotation, an, ctx, getCursor().getParentTreeCursor());
-					}
-               }
+                        return maybeAutoFormat(annotation, an, ctx, getCursor().getParentTreeCursor());
+                    }
+                }
         );
     }
 }

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
@@ -129,6 +129,35 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
 		);
 	}
 
+	@Test
+	void convertApiResponseMapContainers() {
+		//language=java
+		rewriteRun(
+		  java(
+			"""
+              import io.swagger.annotations.ApiResponse;
+              import org.springframework.http.ResponseEntity;
+
+              class A {
+                  @ApiResponse(code = 200, message = "OK", responseContainer = "Map", response = User.class)
+                  ResponseEntity<User> method() { return null; }
+              }
+              """,
+			"""
+              import io.swagger.v3.oas.annotations.media.Content;
+              import io.swagger.v3.oas.annotations.media.Schema;
+              import io.swagger.v3.oas.annotations.responses.ApiResponse;
+              import org.springframework.http.ResponseEntity;
+
+              class A {
+                  @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(type = "object", additionalPropertiesSchema = User.class)))
+                  ResponseEntity<User> method() { return null; }
+              }
+              """
+		  )
+		);
+	}
+
     @Test
     void noChangeOnAlreadyConverted() {
         //language=java

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
@@ -69,6 +69,66 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
         );
     }
 
+	@Test
+	void convertApiResponseListContainers() {
+		//language=java
+		rewriteRun(
+		  java(
+			"""
+              import io.swagger.annotations.ApiResponse;
+              import org.springframework.http.ResponseEntity;
+
+              class A {
+                  @ApiResponse(code = 200, message = "OK", responseContainer = "List", response = User.class)
+                  ResponseEntity<User> method() { return null; }
+              }
+              """,
+			"""
+              import io.swagger.v3.oas.annotations.media.ArraySchema;
+              import io.swagger.v3.oas.annotations.media.Content;
+              import io.swagger.v3.oas.annotations.media.Schema;
+              import io.swagger.v3.oas.annotations.responses.ApiResponse;
+              import org.springframework.http.ResponseEntity;
+
+              class A {
+                  @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", array = @ArraySchema(uniqueItems = false, schema = @Schema(implementation = User.class))))
+                  ResponseEntity<User> method() { return null; }
+              }
+              """
+		  )
+		);
+	}
+
+	@Test
+	void convertApiResponseSetContainers() {
+		//language=java
+		rewriteRun(
+		  java(
+			"""
+              import io.swagger.annotations.ApiResponse;
+              import org.springframework.http.ResponseEntity;
+
+              class A {
+                  @ApiResponse(code = 200, message = "OK", response = User.class, responseContainer = "Set")
+                  ResponseEntity<User> method() { return null; }
+              }
+              """,
+			"""
+              import io.swagger.v3.oas.annotations.media.ArraySchema;
+              import io.swagger.v3.oas.annotations.media.Content;
+              import io.swagger.v3.oas.annotations.media.Schema;
+              import io.swagger.v3.oas.annotations.responses.ApiResponse;
+              import org.springframework.http.ResponseEntity;
+
+              class A {
+                  @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", array = @ArraySchema(uniqueItems = true, schema = @Schema(implementation = User.class))))
+                  ResponseEntity<User> method() { return null; }
+              }
+              """
+		  )
+		);
+	}
+
     @Test
     void noChangeOnAlreadyConverted() {
         //language=java


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Added support for migrating `@ApiResponse` with `responseContainer`.

`@ApiResponse(responseContainer = "List", response = ClassName.class)` -> `@ApiResponse(content = @Content(mediaType = "application/json", array = @ArraySchema(uniqueItems = false, schema = @Schema(implementation = ClassName.class))))`

`@ApiResponse(responseContainer = "Set", response = ClassName.class)` -> `@ApiResponse(content = @Content(mediaType = "application/json", array = @ArraySchema(uniqueItems = true, schema = @Schema(implementation = ClassName.class))))`

`@ApiResponse(responseContainer = "Map", response = ClassName.class)` -> `@ApiResponse(content = @Content(mediaType = "application/json", schema = @Schema(type = "object", additionalPropertiesSchema = ClassName.class)))`

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Migration was not complete without it.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
`responseContainer` only has 3 valid inputs. See [here](https://docs.swagger.io/swagger-core/current/apidocs/io/swagger/annotations/ApiResponse.html#responseContainer()). A `responseContainer` that does not contain any of the 3 valid inputs will be ignored, and will be treated as if `responseContainer` was absent.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
