### PR TITLE
Removed change to non-existent property in MigrateApiModelPropertyToSchema

### DIFF
--- a/src/main/resources/META-INF/rewrite/swagger-2.yml
+++ b/src/main/resources/META-INF/rewrite/swagger-2.yml
@@ -252,7 +252,3 @@ recipeList:
       annotationType: io.swagger.v3.oas.annotations.media.Schema
       newAttributeName: type
       oldAttributeName: dataType
-  - org.openrewrite.java.ChangeAnnotationAttributeName:
-      annotationType: io.swagger.v3.oas.annotations.media.Schema
-      newAttributeName: allowEmptyValue
-      oldAttributeName: nullable


### PR DESCRIPTION
## What's changed?
Removed change to non-existent property

## What's your motivation?
The new proprety does not exist while the old one is valid:
https://javadoc.io/doc/io.swagger.core.v3/swagger-annotations/latest/io/swagger/v3/oas/annotations/media/Schema.html
