### PR TITLE
Adding example showcasing how multiple dependencies that rely on the same property for their version can break when the relevant context for said property changes (like in `ChangeDependency`)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,8 +18,12 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.13.3")
 
-    testRuntimeOnly("io.swagger:swagger-annotations:1.6.13")
-    testRuntimeOnly("io.swagger.core.v3:swagger-annotations:2.2.20")
+    testRuntimeOnly("io.swagger:swagger-annotations:1.5.16")
+    testRuntimeOnly("io.swagger:swagger-models:1.5.16")
+    testRuntimeOnly("io.swagger:swagger-core:1.5.16")
+    testRuntimeOnly("io.swagger.core.v3:swagger-annotations:2.2.34")
+    testRuntimeOnly("io.swagger.core.v3:swagger-models:2.2.34")
+    testRuntimeOnly("io.swagger.core.v3:swagger-core:2.2.34")
     testRuntimeOnly("jakarta.ws.rs:jakarta.ws.rs-api:3.1.0")
 
     testRuntimeOnly("org.gradle:gradle-tooling-api:latest.release")


### PR DESCRIPTION
## What's changed?
- So far just a test, but some logic will likely have to change in how properties get altered when multiple dependencies rely on them.

## What's your motivation?
Dependency resolution breaks right now.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
