### PR TITLE
MigrateApiParamDefaultValue to allow defaultValue in different order

### DIFF
--- a/src/main/java/org/openrewrite/openapi/swagger/MigrateApiParamDefaultValue.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/MigrateApiParamDefaultValue.java
@@ -65,6 +65,8 @@ public class MigrateApiParamDefaultValue extends Recipe {
                             if (isDefaultValue(exp)) {
                                 Expression expression = ((J.Assignment) exp).getAssignment();
                                 addSchema(schemaTpl, "defaultValue");
+                                normalizeSchema(schemaTpl);
+                                tpl.append(schemaTpl).append(", ");
                                 args.add(expression);
                             } else {
                                 tpl.append("#{any()}, ");
@@ -73,13 +75,6 @@ public class MigrateApiParamDefaultValue extends Recipe {
                         }
                         if (tpl.toString().endsWith(", ")) {
                             tpl.delete(tpl.length() - 2, tpl.length());
-                        }
-                        if (schemaTpl.length() > 0) {
-                            if (schemaTpl.toString().endsWith(", ")) {
-                                schemaTpl.delete(schemaTpl.length() - 2, schemaTpl.length());
-                            }
-                            schemaTpl.append(")");
-                            tpl.append(", ").append(schemaTpl);
                         }
                         anno = JavaTemplate.builder(tpl.toString())
                                 .imports(FQN_SCHEMA)
@@ -91,10 +86,19 @@ public class MigrateApiParamDefaultValue extends Recipe {
                     }
 
                     private void addSchema(StringBuilder tpl, String key) {
-                        if (tpl.length() == 0) {
+                    	if (tpl.length() == 0) {
                             tpl.append("schema = @Schema(");
                         }
                         tpl.append(key).append(" = #{any()}, ");
+                    }
+
+                    private void normalizeSchema(StringBuilder schemaTpl) {
+                    	if (schemaTpl.length() > 0) {
+                            if (schemaTpl.toString().endsWith(", ")) {
+                                schemaTpl.delete(schemaTpl.length() - 2, schemaTpl.length());
+                            }
+                            schemaTpl.append(")");
+                        }
                     }
 
                     private boolean isDefaultValue(Expression exp) {

--- a/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
@@ -183,6 +183,37 @@ class SwaggerToOpenAPITest implements RewriteTest {
         );
     }
 
+    /**
+     *
+     * Same test as {@link #migrateApiParam()} making sure the order of the annotation properties doesn't break the logic
+     *
+     */
+    @Test
+    void migrateApiParamDiffOrder() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import io.swagger.annotations.ApiParam;
+
+              class Example {
+                @ApiParam(name = "foo", value = "Foo Object", defaultValue = "bar", required = false)
+                private Integer foo;
+              }
+              """,
+            """
+              import io.swagger.v3.oas.annotations.Parameter;
+              import io.swagger.v3.oas.annotations.media.Schema;
+
+              class Example {
+                @Parameter(name = "foo", description = "Foo Object", schema = @Schema(defaultValue = "bar"), required = false)
+                private Integer foo;
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void migrateSwaggerDefinitionsToOpenAPIDefinitionSingleSchema() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
The parsing logic now adds the generated `schema` property to the resulting string with the value so the placeholder aligns with the order in which the `defaultValue` appears

## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite-openapi/issues/58

## Have you considered any alternatives or workarounds?
Workaround would force users to reformat their annotations to follow the particular ordering

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
