### PR TITLE
change swagger-jersey2-jaxrs dependency to swagger-jaxrs2

### DIFF
--- a/src/main/resources/META-INF/rewrite/swagger-2.yml
+++ b/src/main/resources/META-INF/rewrite/swagger-2.yml
@@ -25,13 +25,15 @@ recipeList:
   # Relocated artifacts https://mvnrepository.com/artifact/io.swagger
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: io.swagger
+      oldArtifactId: swagger-jersey2-jaxrs
+      newGroupId: io.swagger.core.v3
+      newArtifactId: swagger-jaxrs2
+      newVersion: 2.2.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: io.swagger
       oldArtifactId: swagger-*
       newGroupId: io.swagger.core.v3
       newVersion: 2.2.x
-  - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: io.swagger.core.v3
-      oldArtifactId: swagger-jersey2-jaxrs
-      newArtifactId: swagger-jaxrs2
   # https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Annotations
   # https://springdoc.org/#migrating-from-springfox
   - org.openrewrite.java.ChangeType:


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Add a ChangeDependency to make sure `io.swagger:swagger-jersey2-jaxrs` ends up as `io.swagger.core.v3:swagger-jaxrs2`
## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
The way the `org.openrewrite.openapi.swagger.SwaggerToOpenAPI` recipe works, a pom might end up with a dependency on `io.swagger.core.v3:swagger-jersey2-jaxrs:2.2.x`. This change catches the edge case where the `swagger-jersey2-jaxrs` artifact is simply not under the `io.swagger.core.v3` group id. 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
The recipe makes the change to `swagger-jaxrs2`. Further down, there is a ChangeDependency in `org.openrewrite.openapi.swagger.UseJakartaSwaggerArtifacts` that changes  `swagger-jaxrs2` to `swagger-jaxrs2-jakarta`. The UseJakartaSwaggerArtifacts recipe is not invoked from `org.openrewrite.openapi.swagger.SwaggerToOpenAPI`. 
## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
