### PR TITLE
Correcting `artifactId` for `swagger-jaxrs` to `swagger-jaxrs2` when we go to the new `groupId` of `io.swagger.core.v3`, and updated test to show `jersey` artifact combining into the same artifact

### DIFF
--- a/src/main/resources/META-INF/rewrite/swagger-2.yml
+++ b/src/main/resources/META-INF/rewrite/swagger-2.yml
@@ -31,6 +31,12 @@ recipeList:
       newVersion: 2.2.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: io.swagger
+      oldArtifactId: swagger-jaxrs
+      newGroupId: io.swagger.core.v3
+      newArtifactId: swagger-jaxrs2
+      newVersion: 2.2.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: io.swagger
       oldArtifactId: swagger-*
       newGroupId: io.swagger.core.v3
       newVersion: 2.2.x

--- a/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/SwaggerToOpenAPITest.java
@@ -85,6 +85,16 @@ class SwaggerToOpenAPITest implements RewriteTest {
                     <artifactId>swagger-core</artifactId>
                     <version>1.6.14</version>
                   </dependency>
+                  <dependency>
+                    <groupId>io.swagger</groupId>
+                    <artifactId>swagger-jersey2-jaxrs</artifactId>
+                    <version>1.6.14</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>io.swagger</groupId>
+                    <artifactId>swagger-jaxrs</artifactId>
+                    <version>1.6.14</version>
+                  </dependency>
                 </dependencies>
               </project>
               """,
@@ -108,6 +118,11 @@ class SwaggerToOpenAPITest implements RewriteTest {
                   <dependency>
                     <groupId>io.swagger.core.v3</groupId>
                     <artifactId>swagger-core</artifactId>
+                    <version>%1$s</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>io.swagger.core.v3</groupId>
+                    <artifactId>swagger-jaxrs2</artifactId>
                     <version>%1$s</version>
                   </dependency>
                 </dependencies>


### PR DESCRIPTION
## What's changed?
- Explicitly changed `io.swagger:swagger-jaxrs` to `io.swagger.core.v3:swagger-jaxrs2` when migrating to newer Swagger as there isn't a `swagger-jaxrs` in the new `groupId`.

## What's your motivation?
- Compilation failure after OpenAPI migration

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
