### PR TITLE
Handle `responseContainer` without `response` in ApiResponse migration

### DIFF
--- a/src/main/java/org/openrewrite/openapi/swagger/ConvertApiResponseToContent.java
+++ b/src/main/java/org/openrewrite/openapi/swagger/ConvertApiResponseToContent.java
@@ -85,6 +85,21 @@ public class ConvertApiResponseToContent extends Recipe {
                         if (maybeArgsWithoutResponse.size() >= an.getArguments().size()) {
                             return an;
                         }
+                        if (contentClass.get() == null) {
+                            // `responseContainer` without `response` cannot form a content schema; drop it.
+                            String args = StringUtils.repeat("#{any()}, ", maybeArgsWithoutResponse.size());
+                            if (args.endsWith(", ")) {
+                                args = args.substring(0, args.length() - 2);
+                            }
+                            an = JavaTemplate.builder(args)
+                                    .build()
+                                    .apply(
+                                            getCursor(),
+                                            an.getCoordinates().replaceArguments(),
+                                            maybeArgsWithoutResponse.toArray()
+                                    );
+                            return maybeAutoFormat(annotation, an, ctx, getCursor().getParentTreeCursor());
+                        }
                         String inner;
                         String type = containerType.get() != null ? containerType.get().toString() : null;
                         // 1) list/set case: wrap in ArraySchema

--- a/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
+++ b/src/test/java/org/openrewrite/openapi/swagger/MigrateApiResponsesToApiResponsesTest.java
@@ -70,12 +70,12 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
         );
     }
 
-	@Test
-	void convertApiResponseListContainers() {
-		//language=java
-		rewriteRun(
-		  java(
-			"""
+    @Test
+    void convertApiResponseListContainers() {
+        //language=java
+        rewriteRun(
+          java(
+            """
               import io.swagger.annotations.ApiResponse;
               import org.springframework.http.ResponseEntity;
 
@@ -84,7 +84,7 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
                   ResponseEntity<User> method() { return null; }
               }
               """,
-			"""
+            """
               import io.swagger.v3.oas.annotations.media.ArraySchema;
               import io.swagger.v3.oas.annotations.media.Content;
               import io.swagger.v3.oas.annotations.media.Schema;
@@ -96,16 +96,16 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
                   ResponseEntity<User> method() { return null; }
               }
               """
-		  )
-		);
-	}
+          )
+        );
+    }
 
-	@Test
-	void convertApiResponseSetContainers() {
-		//language=java
-		rewriteRun(
-		  java(
-			"""
+    @Test
+    void convertApiResponseSetContainers() {
+        //language=java
+        rewriteRun(
+          java(
+            """
               import io.swagger.annotations.ApiResponse;
               import org.springframework.http.ResponseEntity;
 
@@ -114,7 +114,7 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
                   ResponseEntity<User> method() { return null; }
               }
               """,
-			"""
+            """
               import io.swagger.v3.oas.annotations.media.ArraySchema;
               import io.swagger.v3.oas.annotations.media.Content;
               import io.swagger.v3.oas.annotations.media.Schema;
@@ -126,16 +126,43 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
                   ResponseEntity<User> method() { return null; }
               }
               """
-		  )
-		);
-	}
+          )
+        );
+    }
 
-	@Test
-	void convertApiResponseMapContainers() {
-		//language=java
-		rewriteRun(
-		  java(
-			"""
+    @Test
+    void convertApiResponseContainerWithoutResponse() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import io.swagger.annotations.ApiResponse;
+              import org.springframework.http.ResponseEntity;
+
+              class A {
+                  @ApiResponse(code = 200, message = "OK", responseContainer = "List")
+                  ResponseEntity<Void> method() { return null; }
+              }
+              """,
+            """
+              import io.swagger.v3.oas.annotations.responses.ApiResponse;
+              import org.springframework.http.ResponseEntity;
+
+              class A {
+                  @ApiResponse(responseCode = "200", description = "OK")
+                  ResponseEntity<Void> method() { return null; }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void convertApiResponseMapContainers() {
+        //language=java
+        rewriteRun(
+          java(
+            """
               import io.swagger.annotations.ApiResponse;
               import org.springframework.http.ResponseEntity;
 
@@ -144,7 +171,7 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
                   ResponseEntity<User> method() { return null; }
               }
               """,
-			"""
+            """
               import io.swagger.v3.oas.annotations.media.Content;
               import io.swagger.v3.oas.annotations.media.Schema;
               import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -155,9 +182,9 @@ class MigrateApiResponsesToApiResponsesTest implements RewriteTest {
                   ResponseEntity<User> method() { return null; }
               }
               """
-		  )
-		);
-	}
+          )
+        );
+    }
 
     @Test
     void noChangeOnAlreadyConverted() {


### PR DESCRIPTION
## Summary
- Fixes #74: `ConvertApiResponseToContent` crashed with `IllegalArgumentException: This template requires more parameters` when `@ApiResponse` had `responseContainer` (e.g. `"List"`) but no `response` attribute.
- When `contentClass` is null, drop the orphan `responseContainer` (no v3 equivalent) and emit the annotation without a `content` schema.
- Adds a regression test covering `responseContainer = "List"` without `response`.

## Test plan
- [x] `./gradlew test`